### PR TITLE
Explicitely state that a reassignment is a noop

### DIFF
--- a/main.go
+++ b/main.go
@@ -775,7 +775,7 @@ func whatChanged(s1 []int, s2 []int) string {
 
 	// Nothing changed.
 	if !changed {
-		return ""
+		return "no-op"
 	}
 
 	sort.Ints(a)


### PR DESCRIPTION
This will also help for `grep -v`