### PR TITLE
jamie/partition factor

### DIFF
--- a/cmd/topicmappr/main.go
+++ b/cmd/topicmappr/main.go
@@ -38,6 +38,7 @@ var (
 		placement       string
 		optimize        string
 		verbose         bool
+		partnSzFactor   float64
 	}
 )
 
@@ -59,6 +60,7 @@ func init() {
 	flag.BoolVar(&Config.subAffinity, "sub-affinity", false, "Replacement broker substitution affinity")
 	flag.StringVar(&Config.placement, "placement", "count", "Partition placement strategy: [count, storage]")
 	flag.StringVar(&Config.optimize, "optimize", "distribution", "Optimization priority for the storage placement strategy: [distribution, storage]")
+	flag.Float64Var(&Config.partnSzFactor, "partition-size-factor", 1.0, "Factor by which to multiply partition sizes when using storage placement")
 	brokers := flag.String("brokers", "", "Broker list to scope all partition placements to")
 
 	envy.Parse("TOPICMAPPR")

--- a/cmd/topicmappr/steps.go
+++ b/cmd/topicmappr/steps.go
@@ -251,10 +251,11 @@ func updateReplicationFactor(pm *kafkazk.PartitionMap) {
 // warnings / advisories is returned if any are encountered.
 func buildMap(pm *kafkazk.PartitionMap, pmm kafkazk.PartitionMetaMap, bm kafkazk.BrokerMap, af kafkazk.SubstitutionAffinities) (*kafkazk.PartitionMap, []string) {
 	rebuildParams := kafkazk.RebuildParams{
-		PMM:          pmm,
-		BM:           bm,
-		Strategy:     Config.placement,
-		Optimization: Config.optimize,
+		PMM:           pmm,
+		BM:            bm,
+		Strategy:      Config.placement,
+		Optimization:  Config.optimize,
+		PartnSzFactor: Config.partnSzFactor,
 	}
 
 	if af != nil {
@@ -361,6 +362,9 @@ func printBrokerAssignmentStats(pm1, pm2 *kafkazk.PartitionMap, bm1, bm2 kafkazk
 	var div = 1073741824.00 // Fixed on GB for now.
 	if Config.placement == "storage" {
 		fmt.Println("\nStorage free change estimations:")
+		if Config.partnSzFactor != 1.0 {
+			fmt.Printf("%sPartition size factor of %.2f applied\n", indent, Config.partnSzFactor)
+		}
 
 		// Get filtered BrokerMaps. For the 'before' broker statistics, we want
 		// all brokers in the original BrokerMap that were also in the input PartitionMap.

--- a/cmd/topicmappr/steps.go
+++ b/cmd/topicmappr/steps.go
@@ -264,16 +264,16 @@ func buildMap(pm *kafkazk.PartitionMap, pmm kafkazk.PartitionMetaMap, bm kafkazk
 	// If we're doing a force rebuild, the input map
 	// must have all brokers stripped out.
 	// A few notes about doing force rebuilds:
-	//	- Map rebuilds should always be called on a stripped PartitionMap copy.
-	//  - The BrokerMap provided in the Rebuild call should have
-	//		been built from the original PartitionMap, not the stripped map.
-	//  - A force rebuild assumes that all partitions will be lifted from
-	// 		all brokers and repositioned. This means you should call the
-	// 		SubStorageAll method on the BrokerMap if we're doing a "storage" placement strategy.
-	//		The SubStorageAll takes a PartitionMap and PartitionMetaMap. The PartitionMap is
-	// 		used to find partition to broker relationships so that the storage used can
-	//		be readded to the broker's StorageFree value. The amount to be readded, the
-	//		size of the partition, is referenced from the PartitionMetaMap.
+	// - Map rebuilds should always be called on a stripped PartitionMap copy.
+	// - The BrokerMap provided in the Rebuild call should have
+	//   been built from the original PartitionMap, not the stripped map.
+	// - A force rebuild assumes that all partitions will be lifted from
+	//   all brokers and repositioned. This means you should call the
+	//   SubStorageAll method on the BrokerMap if we're doing a "storage" placement strategy.
+	//   The SubStorageAll takes a PartitionMap and PartitionMetaMap. The PartitionMap is
+	//   used to find partition to broker relationships so that the storage used can
+	//   be readded to the broker's StorageFree value. The amount to be readded, the
+	//   size of the partition, is referenced from the PartitionMetaMap.
 
 	if Config.forceRebuild {
 		// Get a stripped map that we'll call rebuild on.

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -107,12 +107,13 @@ func (pmm PartitionMetaMap) Size(p Partition) (float64, error) {
 // parameters to call the Rebuild
 // method on a *PartitionMap.
 type RebuildParams struct {
-	pm           *PartitionMap
-	PMM          PartitionMetaMap
-	BM           BrokerMap
-	Strategy     string
-	Optimization string
-	Affinities   SubstitutionAffinities
+	pm            *PartitionMap
+	PMM           PartitionMetaMap
+	BM            BrokerMap
+	Strategy      string
+	Optimization  string
+	Affinities    SubstitutionAffinities
+	PartnSzFactor float64
 }
 
 // Rebuild takes a BrokerMap and rebuild strategy.
@@ -249,7 +250,7 @@ func placeByPosition(params RebuildParams) (*PartitionMap, []string) {
 						continue
 					}
 
-					constraints.requestSize = s
+					constraints.requestSize = s * params.PartnSzFactor
 				}
 
 				// Fetch the best candidate and append.
@@ -361,7 +362,7 @@ func placeByPartition(params RebuildParams) (*PartitionMap, []string) {
 						continue
 					}
 
-					constraints.requestSize = s
+					constraints.requestSize = s * params.PartnSzFactor
 				}
 
 				// Fetch the best candidate and append.

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -147,13 +147,12 @@ func (pm *PartitionMap) Rebuild(params RebuildParams) (*PartitionMap, []string) 
 		case "storage":
 			newMap, errs = placeByPartition(params)
 			// Shuffle replica sets. placeByPartition
-			// suffers from optimal leadership distribution
+			// suffers from suboptimal leadership distribution
 			// because of the requirement to choose all
 			// brokers for each partition at a time (in contrast
 			// to placeByPosition). Shuffling has proven so far
 			// to distribute leadership even though it's purely
-			// by probability. If cases are found that this proves
-			// unsuitable, a real optimizer will be written.
+			// by probability. TODO eventually, write a real optimizer.
 			newMap.shuffle()
 		// Invalid optimization.
 		default:


### PR DESCRIPTION
Adds the `-partition-size-factor` flag which allows partition sizes to be manipulated by a factor to simulate increases or decreases in partition sizes while performing storage placements.

An example use case would be if we wanted to perform a storage placement for a topic that will have have the retention increased by 50%, we could specify `-partition-size-factor 1.5`. When assigning brokers, the storage demand from each partition will be increased by 50%.

Closes #181 