### PR TITLE
Add flag to Ignore no-op remappings, to alleviate the reassignment payload

### DIFF
--- a/cmd/topicmappr/commands/rebuildtopics.go
+++ b/cmd/topicmappr/commands/rebuildtopics.go
@@ -197,6 +197,13 @@ func rebuild(cmd *cobra.Command, _ []string) {
 		fmt.Printf("%s[none]\n", indent)
 	}
 
+	// Ignore no-ops in the case of a substitution affinity. As we only care
+	// about broker replacement, the no-ops would inflate the assignment size,
+	// which would put load on the controller for no useful reason.
+	if sa {
+		originalMap, partitionMapOut = ignoreNoOpRemappings(originalMap, partitionMapOut)
+	}
+
 	// Print map change results.
 	printMapChanges(originalMap, partitionMapOut)
 

--- a/cmd/topicmappr/commands/rebuildtopics_steps.go
+++ b/cmd/topicmappr/commands/rebuildtopics_steps.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"time"
 
@@ -331,6 +332,23 @@ func buildMap(cmd *cobra.Command, pm *kafkazk.PartitionMap, pmm kafkazk.Partitio
 		// Rebuild directly on the input map.
 		return pm.Rebuild(rebuildParams)
 	}
+}
+
+// ignoreNoOps removes no-op partition map changes
+// from the input and final output PartitionMap
+func ignoreNoOpRemappings(pm1, pm2 *kafkazk.PartitionMap) (*kafkazk.PartitionMap, *kafkazk.PartitionMap) {
+	prunedInputPartitionMap := kafkazk.NewPartitionMap()
+	prunedOutputPartitionMap := kafkazk.NewPartitionMap()
+	for i := range pm1.Partitions {
+		r1, r2 := pm1.Partitions[i].Replicas, pm2.Partitions[i].Replicas
+		if !reflect.DeepEqual(r1, r2) {
+			prunedInputPartitionMap.Partitions = append(
+				prunedInputPartitionMap.Partitions, pm1.Partitions[i])
+			prunedOutputPartitionMap.Partitions = append(
+				prunedOutputPartitionMap.Partitions, pm2.Partitions[i])
+		}
+	}
+	return prunedInputPartitionMap, prunedOutputPartitionMap
 }
 
 // printMapChanges takes the original input PartitionMap

--- a/cmd/topicmappr/commands/rebuildtopics_steps.go
+++ b/cmd/topicmappr/commands/rebuildtopics_steps.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"sort"
 	"time"
 
@@ -334,18 +333,16 @@ func buildMap(cmd *cobra.Command, pm *kafkazk.PartitionMap, pmm kafkazk.Partitio
 	}
 }
 
-// ignoreNoOps removes no-op partition map changes
+// ignoreNoOpRemappings removes no-op partition map changes
 // from the input and final output PartitionMap
 func ignoreNoOpRemappings(pm1, pm2 *kafkazk.PartitionMap) (*kafkazk.PartitionMap, *kafkazk.PartitionMap) {
 	prunedInputPartitionMap := kafkazk.NewPartitionMap()
 	prunedOutputPartitionMap := kafkazk.NewPartitionMap()
 	for i := range pm1.Partitions {
-		r1, r2 := pm1.Partitions[i].Replicas, pm2.Partitions[i].Replicas
-		if !reflect.DeepEqual(r1, r2) {
-			prunedInputPartitionMap.Partitions = append(
-				prunedInputPartitionMap.Partitions, pm1.Partitions[i])
-			prunedOutputPartitionMap.Partitions = append(
-				prunedOutputPartitionMap.Partitions, pm2.Partitions[i])
+		p1, p2 := pm1.Partitions[i], pm2.Partitions[i]
+		if !p1.Equal(p2) {
+			prunedInputPartitionMap.Partitions = append(prunedInputPartitionMap.Partitions, p1)
+			prunedOutputPartitionMap.Partitions = append(prunedOutputPartitionMap.Partitions, p2)
 		}
 	}
 	return prunedInputPartitionMap, prunedOutputPartitionMap

--- a/cmd/topicmappr/commands/root.go
+++ b/cmd/topicmappr/commands/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "topicmappr",
+	Use: "topicmappr",
 }
 
 func Execute() {

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -18,6 +18,26 @@ type Partition struct {
 	Replicas  []int  `json:"replicas"`
 }
 
+// Equal defines equalty between two Partition objects
+// as an equality of topic, partition and replicas.
+func (p Partition) Equal(p2 Partition) bool {
+	if p.Topic != p2.Topic {
+		return false
+	}
+	if p.Partition != p2.Partition {
+		return false
+	}
+	if len(p.Replicas) != len(p2.Replicas) {
+		return false
+	}
+	for i := range p.Replicas {
+		if p.Replicas[i] != p2.Replicas[i] {
+			return false
+		}
+	}
+	return true
+}
+
 type partitionList []Partition
 
 // PartitionMap maps the

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -6,14 +6,15 @@ import (
 	"sort"
 	"testing"
 )
-func TestPartitionEquality(t *testing.T) {
-	p1 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3} }
-	p2 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3} }
-	p3 := Partition{Topic: "other_topic", Partition: 1, Replicas: []int{1, 2, 3} }
-	p4 := Partition{Topic: "test_topic", Partition: 2, Replicas: []int{1, 2, 3} }
-	p5 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{4, 5, 6} }
 
-	if ! p1.Equal(p2) {
+func TestPartitionEquality(t *testing.T) {
+	p1 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3}}
+	p2 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3}}
+	p3 := Partition{Topic: "other_topic", Partition: 1, Replicas: []int{1, 2, 3}}
+	p4 := Partition{Topic: "test_topic", Partition: 2, Replicas: []int{1, 2, 3}}
+	p5 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{4, 5, 6}}
+
+	if !p1.Equal(p2) {
 		t.Error("Unexpected inequality between p1 and p2")
 	}
 	if p1.Equal(p3) {

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -6,6 +6,26 @@ import (
 	"sort"
 	"testing"
 )
+func TestPartitionEquality(t *testing.T) {
+	p1 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3} }
+	p2 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{1, 2, 3} }
+	p3 := Partition{Topic: "other_topic", Partition: 1, Replicas: []int{1, 2, 3} }
+	p4 := Partition{Topic: "test_topic", Partition: 2, Replicas: []int{1, 2, 3} }
+	p5 := Partition{Topic: "test_topic", Partition: 1, Replicas: []int{4, 5, 6} }
+
+	if ! p1.Equal(p2) {
+		t.Error("Unexpected inequality between p1 and p2")
+	}
+	if p1.Equal(p3) {
+		t.Error("Unexpected equality between p1 and p3")
+	}
+	if p1.Equal(p4) {
+		t.Error("Unexpected equality between p1 and p4")
+	}
+	if p1.Equal(p5) {
+		t.Error("Unexpected equality between p1 and p5")
+	}
+}
 
 func testGetMapString(n string) string {
 	return fmt.Sprintf(`{"version":1,"partitions":[


### PR DESCRIPTION
When we lose a broker that was assigned a large number of partitions spanning a large number of topics in a single map, `topicmappr` ends up generating a large reassignment file, containing a majority of no-ops partition mappings. 

We've observed that this large reassignment puts a heavy load on the kafka controller, overloading it for a time. The reassignment, although being successful, takes a long while to process.

That PR makes sure to exclude all no-ops partition mappings from a sub-affinity (aka broker replacement) reassignment, to alleviate it as much as possible.

Example

```
$ ./topicmappr-custom-build rebuild-topics \
  --topics '__consumer_offsets'\
  --brokers '1577,1578,1579,1580,1078,1582,1647,1584,1585,1586,1587,1588,1589,1590,1591,1592,1593' \
  --ignore-warns=false \
  --sub-affinity=true \
  --skip-no-ops

Topics:
  __consumer_offsets

Broker change summary:
  Broker 1583 marked for removal
  New broker 1078
  -
  Substitution affinity: 1583 -> 1078
  -
  Replacing 1, added 1, missing 0, total count changed by 0

Action:
  Rebuild topic with 1 broker(s) marked for replacement

WARN:
  [none]

Partition map changes:
  __consumer_offsets p1: [1583 1586 1578] -> [1078 1586 1578] replaced broker
  __consumer_offsets p3: [1587 1583 1590] -> [1587 1078 1590] replaced broker
  __consumer_offsets p5: [1579 1585 1583] -> [1579 1585 1078] replaced broker
  __consumer_offsets p18: [1583 1585 1577] -> [1078 1585 1577] replaced broker
  __consumer_offsets p25: [1647 1583 1585] -> [1647 1078 1585] replaced broker
  __consumer_offsets p29: [1585 1593 1583] -> [1585 1593 1078] replaced broker
  __consumer_offsets p35: [1583 1590 1588] -> [1078 1590 1588] replaced broker
  __consumer_offsets p38: [1588 1583 1590] -> [1588 1078 1590] replaced broker
  __consumer_offsets p49: [1586 1647 1583] -> [1586 1647 1078] replaced broker

Broker distribution:
  degree [min/max/avg]: 2/10/3.27 -> 2/10/3.27
  -
  Broker 1078 - leader: 3, follower: 6, total: 9
  Broker 1577 - leader: 0, follower: 1, total: 1
  Broker 1578 - leader: 0, follower: 1, total: 1
  Broker 1579 - leader: 1, follower: 0, total: 1
  Broker 1585 - leader: 1, follower: 3, total: 4
  Broker 1586 - leader: 1, follower: 1, total: 2
  Broker 1587 - leader: 1, follower: 0, total: 1
  Broker 1588 - leader: 1, follower: 1, total: 2
  Broker 1590 - leader: 0, follower: 3, total: 3
  Broker 1593 - leader: 0, follower: 1, total: 1
  Broker 1647 - leader: 1, follower: 1, total: 2

New partition maps:
  __consumer_offsets.json

$  cat __consumer_offsets.json| jq ".partitions[].partition"
1
3
5
18
25
29
35
38
49
``` 

That reassignment would have previously contained a partition mapping for all the topic partitions, `n - 9` of them being no-ops.