### PR TITLE
jamie/stub-broker-id

### DIFF
--- a/cmd/registry/README.md
+++ b/cmd/registry/README.md
@@ -7,7 +7,7 @@ The Registry service exposes Kafka topic and broker metadata via a gRPC & HTTP A
 # Installation
 - `go get github.com/DataDog/kafka-kit/cmd/registry`
 
-Binary will be found at `$GOPATH/bin/autothrottle`
+Binary will be found at `$GOPATH/bin/registry`
 
 # Usage
 

--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -52,9 +52,8 @@ func getBrokerMeta(cmd *cobra.Command, zk kafkazk.Handler, m bool) kafkazk.Broke
 // and have a non-true MetricsIncomplete value.
 func ensureBrokerMetrics(cmd *cobra.Command, bm kafkazk.BrokerMap, bmm kafkazk.BrokerMetaMap) {
 	for id, b := range bm {
-		// Missing brokers won't even
-		// be found in the brokerMeta.
-		if !b.Missing && id != 0 && bmm[id].MetricsIncomplete {
+		// Missing brokers won't be found in the brokerMeta.
+		if !b.Missing && id != kafkazk.StubBrokerID && bmm[id].MetricsIncomplete {
 			fmt.Printf("Metrics not found for broker %d\n", id)
 			os.Exit(1)
 		}

--- a/kafkazk/brokers.go
+++ b/kafkazk/brokers.go
@@ -6,6 +6,11 @@ import (
 	"sort"
 )
 
+const (
+	// StubBrokerID is the platform int max.
+	StubBrokerID int = int(^uint(0) >> 1)
+)
+
 // BrokerMetaMap is a map of broker IDs to BrokerMeta
 // metadata fetched from ZooKeeper. Currently, just
 // the rack field is retrieved.
@@ -199,8 +204,8 @@ func (b BrokerMap) Update(bl []int, bm BrokerMetaMap) (*BrokerStatus, <-chan str
 	// and see if any are missing in ZooKeeper.
 	if len(bm) > 0 {
 		for id := range b {
-			// Skip reserved ID 0.
-			if id == 0 {
+			// Skip the reserved ID.
+			if id == StubBrokerID {
 				continue
 			}
 
@@ -222,10 +227,7 @@ func (b BrokerMap) Update(bl []int, bm BrokerMetaMap) (*BrokerStatus, <-chan str
 	// Set the replace flag for existing brokers
 	// not in the new broker map.
 	for _, broker := range b {
-		// Broker ID 0 is a special stub
-		// ID used for internal purposes.
-		// Skip it.
-		if broker.ID == 0 {
+		if broker.ID == StubBrokerID {
 			continue
 		}
 
@@ -317,7 +319,7 @@ func (b BrokerMap) Filter(f func(*Broker) bool) BrokerMap {
 	bmap := BrokerMap{}
 
 	for _, broker := range b {
-		if broker.ID == 0 {
+		if broker.ID == StubBrokerID {
 			continue
 		}
 
@@ -372,11 +374,8 @@ func BrokerMapFromPartitionMap(pm *PartitionMap, bm BrokerMetaMap, force bool) B
 		}
 	}
 
-	// Broker ID 0 is used for --force-rebuild.
-	// We request a Stripped map which replaces
-	// all existing brokers with the fake broker
-	// with ID set for replacement.
-	bmap[0] = &Broker{Used: 0, ID: 0, Replace: true}
+	// Include the StubBrokerID.
+	bmap[StubBrokerID] = &Broker{Used: 0, ID: StubBrokerID, Replace: true}
 
 	return bmap
 }

--- a/kafkazk/brokers_test.go
+++ b/kafkazk/brokers_test.go
@@ -150,7 +150,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Ensure all broker IDs are in the map.
-	for _, id := range []int{0, 1001, 1002, 1003, 1004, 1005} {
+	for _, id := range []int{StubBrokerID, 1001, 1002, 1003, 1004, 1005} {
 		if _, ok := bm[id]; !ok {
 			t.Errorf("Expected presence of ID %d", id)
 		}
@@ -363,23 +363,23 @@ func TestBrokerCopy(t *testing.T) {
 
 func newMockBrokerMap() BrokerMap {
 	return BrokerMap{
-		0:    &Broker{ID: 0, Replace: true},
-		1001: &Broker{ID: 1001, Locality: "a", Used: 3, Replace: false, StorageFree: 100.00},
-		1002: &Broker{ID: 1002, Locality: "b", Used: 3, Replace: false, StorageFree: 200.00},
-		1003: &Broker{ID: 1003, Locality: "c", Used: 2, Replace: false, StorageFree: 300.00},
-		1004: &Broker{ID: 1004, Locality: "a", Used: 2, Replace: false, StorageFree: 400.00},
+		StubBrokerID: &Broker{ID: StubBrokerID, Replace: true},
+		1001:         &Broker{ID: 1001, Locality: "a", Used: 3, Replace: false, StorageFree: 100.00},
+		1002:         &Broker{ID: 1002, Locality: "b", Used: 3, Replace: false, StorageFree: 200.00},
+		1003:         &Broker{ID: 1003, Locality: "c", Used: 2, Replace: false, StorageFree: 300.00},
+		1004:         &Broker{ID: 1004, Locality: "a", Used: 2, Replace: false, StorageFree: 400.00},
 	}
 }
 
 func newMockBrokerMap2() BrokerMap {
 	return BrokerMap{
-		0:    &Broker{ID: 0, Replace: true},
-		1001: &Broker{ID: 1001, Locality: "a", Used: 2, Replace: false, StorageFree: 100.00},
-		1002: &Broker{ID: 1002, Locality: "b", Used: 2, Replace: false, StorageFree: 200.00},
-		1003: &Broker{ID: 1003, Locality: "c", Used: 3, Replace: false, StorageFree: 300.00},
-		1004: &Broker{ID: 1004, Locality: "a", Used: 2, Replace: false, StorageFree: 400.00},
-		1005: &Broker{ID: 1005, Locality: "b", Used: 2, Replace: false, StorageFree: 400.00},
-		1006: &Broker{ID: 1006, Locality: "c", Used: 3, Replace: false, StorageFree: 400.00},
-		1007: &Broker{ID: 1007, Locality: "a", Used: 3, Replace: false, StorageFree: 400.00},
+		StubBrokerID: &Broker{ID: StubBrokerID, Replace: true},
+		1001:         &Broker{ID: 1001, Locality: "a", Used: 2, Replace: false, StorageFree: 100.00},
+		1002:         &Broker{ID: 1002, Locality: "b", Used: 2, Replace: false, StorageFree: 200.00},
+		1003:         &Broker{ID: 1003, Locality: "c", Used: 3, Replace: false, StorageFree: 300.00},
+		1004:         &Broker{ID: 1004, Locality: "a", Used: 2, Replace: false, StorageFree: 400.00},
+		1005:         &Broker{ID: 1005, Locality: "b", Used: 2, Replace: false, StorageFree: 400.00},
+		1006:         &Broker{ID: 1006, Locality: "c", Used: 3, Replace: false, StorageFree: 400.00},
+		1007:         &Broker{ID: 1007, Locality: "a", Used: 3, Replace: false, StorageFree: 400.00},
 	}
 }

--- a/kafkazk/constraints.go
+++ b/kafkazk/constraints.go
@@ -49,7 +49,7 @@ func (b BrokerList) BestCandidate(c *Constraints, by string, p int64) (*Broker, 
 
 	// Iterate over candidates.
 	for _, candidate = range b {
-		if candidate.ID == 0 {
+		if candidate.ID == StubBrokerID {
 			continue
 		}
 

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -658,21 +658,24 @@ func (pm *PartitionMap) equal(pm2 *PartitionMap) (bool, error) {
 }
 
 // Strip takes a PartitionMap and returns a copy where all broker ID
-// references are replaced with the stub broker with ID 0 where the replace
-// field is set to true. This ensures that the entire map is rebuilt, even
-// if the provided broker list matches what's already in the map.
+// references are replaced with the stub broker (ID == StubBrokerID) with
+// the replace field is set to true. This ensures that the entire map is
+// rebuilt, even if the provided broker list matches what's already in the map.
 func (pm *PartitionMap) Strip() *PartitionMap {
 	Stripped := NewPartitionMap()
 
 	// Copy each partition sans the replicas list.
-	// The make([]int, ...) defaults the replica set to
-	// ID 0, which is a default stub broker with replace
-	// set to true.
+	// The new replica list is all stub brokers.
 	for _, p := range pm.Partitions {
+		var stubs = make([]int, len(p.Replicas))
+		for i := range stubs {
+			stubs[i] = StubBrokerID
+		}
+
 		part := Partition{
 			Topic:     p.Topic,
 			Partition: p.Partition,
-			Replicas:  make([]int, len(p.Replicas)),
+			Replicas:  stubs,
 		}
 
 		Stripped.Partitions = append(Stripped.Partitions, part)

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -264,7 +264,7 @@ func TestStrip(t *testing.T) {
 
 	for _, p := range spm.Partitions {
 		for _, b := range p.Replicas {
-			if b != 0 {
+			if b != StubBrokerID {
 				t.Errorf("Unexpected non-stub broker ID %d", b)
 			}
 		}

--- a/kafkazk/stats.go
+++ b/kafkazk/stats.go
@@ -100,7 +100,7 @@ func (b BrokerMap) StorageDiff(b2 BrokerMap) map[int][2]float64 {
 	d := map[int][2]float64{}
 
 	for bid := range b {
-		if bid == 0 {
+		if bid == StubBrokerID {
 			continue
 		}
 

--- a/kafkazk/stats.go
+++ b/kafkazk/stats.go
@@ -137,7 +137,7 @@ func (b BrokerMap) minMax() (float64, float64) {
 	h, l := 0.00, math.MaxFloat64
 
 	for id := range b {
-		if id == 0 {
+		if id == StubBrokerID {
 			continue
 		}
 
@@ -165,7 +165,7 @@ func (b BrokerMap) StorageStdDev() float64 {
 	var l float64
 
 	for id := range b {
-		if id == 0 {
+		if id == StubBrokerID {
 			continue
 		}
 		l++
@@ -175,7 +175,7 @@ func (b BrokerMap) StorageStdDev() float64 {
 	m = t / l
 
 	for id := range b {
-		if id == 0 {
+		if id == StubBrokerID {
 			continue
 		}
 		s += math.Pow(m-b[id].StorageFree, 2)
@@ -192,7 +192,7 @@ func (b BrokerMap) HMean() float64 {
 	var c float64
 
 	for _, br := range b {
-		if br.ID != 0 && br.StorageFree > 0 {
+		if br.ID != StubBrokerID && br.StorageFree > 0 {
 			c++
 			t += (1.00 / br.StorageFree)
 		}
@@ -207,7 +207,7 @@ func (b BrokerMap) Mean() float64 {
 	var c float64
 
 	for _, br := range b {
-		if br.ID != 0 && br.StorageFree > 0 {
+		if br.ID != StubBrokerID && br.StorageFree > 0 {
 			c++
 			t += br.StorageFree
 		}
@@ -227,7 +227,7 @@ func (b BrokerMap) AboveMean(d float64, f func() float64) []int {
 	}
 
 	for _, br := range b {
-		if br.ID == 0 {
+		if br.ID == StubBrokerID {
 			continue
 		}
 
@@ -252,7 +252,7 @@ func (b BrokerMap) BelowMean(d float64, f func() float64) []int {
 	}
 
 	for _, br := range b {
-		if br.ID == 0 {
+		if br.ID == StubBrokerID {
 			continue
 		}
 

--- a/kafkazk/subaffinity.go
+++ b/kafkazk/subaffinity.go
@@ -40,7 +40,7 @@ func (b BrokerMap) SubstitutionAffinities(pm *PartitionMap) (SubstitutionAffinit
 	// Map brokers according to their status.
 	for _, broker := range b {
 		switch {
-		case broker.ID == 0:
+		case broker.ID == StubBrokerID:
 			continue
 		case broker.Missing:
 			missing[broker] = struct{}{}


### PR DESCRIPTION
Changes the internally reserved 'stub' broker ID from 0 to the platform int max. This allows proper use of topicmappr in environments where broker IDs start at 0.

Closes #225.