### PR TITLE
Expanding replica set should use stub brokers for new brokers

### DIFF
--- a/kafkazk/constraints.go
+++ b/kafkazk/constraints.go
@@ -86,8 +86,8 @@ func (c *Constraints) passes(b *Broker) bool {
 	// IDs already in the replica set.
 	case c.id[b.ID]:
 		return false
-		// Fail if the candidate is in any of
-		// the existing replica set localities.
+	// Fail if the candidate is in any of
+	// the existing replica set localities.
 	case c.locality[b.Locality]:
 		return false
 	// Fail if the candidate would run

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -601,6 +601,9 @@ func (pm *PartitionMap) SetReplication(r int) {
 		// Add stub brokers to meet r.
 		case l < r:
 			r := make([]int, r-l)
+			for i := 0; i < len(r); i++ {
+				r[i] = StubBrokerID
+			}
 			pm.Partitions[n].Replicas = append(p.Replicas, r...)
 		}
 	}

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -255,6 +255,26 @@ func TestSetReplication(t *testing.T) {
 			t.Errorf("Expected 2 replicas, got %d", len(r.Replicas))
 		}
 	}
+
+	pm.SetReplication(3)
+	// Replica sets should be expanded with stub brokers
+	for _, r := range pm.Partitions {
+		if len(r.Replicas) != 3 {
+			t.Errorf("Expected 3 replicas, got %d", len(r.Replicas))
+		}
+
+		for bIndex := 0; bIndex < 3; bIndex++ {
+			if bIndex < 2 {
+				if r.Replicas[bIndex] == StubBrokerID {
+					t.Errorf("Expected existing replicas not to be stub brokers, got %d", r.Replicas[bIndex])
+				}
+			} else {
+				if r.Replicas[bIndex] != StubBrokerID {
+					t.Errorf("Expected extended replicas to be stub brokers, got %d", r.Replicas[bIndex])
+				}
+			}
+		}
+	}
 }
 
 func TestStrip(t *testing.T) {


### PR DESCRIPTION
I'm new to `go` so do correct me if I'm not following any conventions I'm not aware of