### PR TITLE
jamie/ignore small partitions

### DIFF
--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -105,20 +105,21 @@ Usage:
   topicmappr rebalance [flags]
 
 Flags:
-      --brokers string               Broker list to scope all partition placements to
-  -h, --help                         help for rebalance
-      --locality-scoped              Disallow a relocation to traverse rack.id values among brokers
-      --metrics-age int              Kafka metrics age tolerance (in minutes) (default 60)
-      --optimize-leaders             Perform a naive leadership optimization
-      --out-file string              If defined, write a combined map of all topics to a file
-      --out-path string              Path to write output map files to
-      --partition-limit int          Limit the number of top partitions by size eligible for relocation per broker (default 30)
-      --storage-threshold float      Percent below the harmonic mean storage free to target for partition offload (default 0.2)
-      --storage-threshold-gb float   Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold
-      --tolerance float              Percent distance from the mean storage free to limit storage scheduling (0 targets a brokers) (default 0.1)
-      --topics string                Rebuild topics (comma delim. list) by lookup in ZooKeeper
-      --verbose                      Verbose output
-      --zk-metrics-prefix string     ZooKeeper namespace prefix for Kafka metrics (default "topicmappr")
+      --brokers string                 Broker list to scope all partition placements to
+  -h, --help                           help for rebalance
+      --locality-scoped                Disallow a relocation to traverse rack.id values among brokers
+      --metrics-age int                Kafka metrics age tolerance (in minutes) (default 60)
+      --optimize-leaders               Perform a naive leadership optimization
+      --out-file string                If defined, write a combined map of all topics to a file
+      --out-path string                Path to write output map files to
+      --partition-limit int            Limit the number of top partitions by size eligible for relocation per broker (default 30)
+      --partition-size-threshold int   Size in megabytes where partitions below this value will not be moved in a rebalance (default 512)
+      --storage-threshold float        Percent below the harmonic mean storage free to target for partition offload (default 0.2)
+      --storage-threshold-gb float     Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold
+      --tolerance float                Percent distance from the mean storage free to limit storage scheduling (0 targets a brokers) (default 0.1)
+      --topics string                  Rebuild topics (comma delim. list) by lookup in ZooKeeper
+      --verbose                        Verbose output
+      --zk-metrics-prefix string       ZooKeeper namespace prefix for Kafka metrics (default "topicmappr")
 
 Global Flags:
       --ignore-warns       Produce a map even if warnings are encountered [TOPICMAPPR_IGNORE_WARNS]


### PR DESCRIPTION
When performing a rebalance, an unused topic (or one with very small partitions) may result in a large number of partitions being needlessly relocated. This PR adds a `--partition-size-threshold` flag which doesn't schedule relocation for partitions lower than this value (defaults to `512MB`).