### PR TITLE
fixes storage calcs in rebuild

### DIFF
--- a/kafkazk/constraints.go
+++ b/kafkazk/constraints.go
@@ -59,6 +59,7 @@ func (c *Constraints) SelectBroker(b BrokerList, p ConstraintsParams) (*Broker, 
 	for _, candidate = range b.Filter(AllBrokersFn) {
 		// Candidate passes, return.
 		if c.passesWithParams(candidate, p) {
+			c.requestSize = p.RequestSize
 			c.Add(candidate)
 			candidate.Used++
 

--- a/kafkazk/constraints_test.go
+++ b/kafkazk/constraints_test.go
@@ -66,14 +66,14 @@ func TestSelectBrokerByStorage(t *testing.T) {
 	// Removes any brokers with locality
 	// "b" as candidates.
 	c.locality["c"] = true
-	// Sets request size.
-	c.requestSize = 1000.00
 
 	p := ConstraintsParams{
 		SelectorMethod: "storage",
+		RequestSize:    1000.00,
 	}
 
 	b, _ := c.SelectBroker(bl, p)
+
 	// 1003 should be the first available.
 	if b.ID != 1003 {
 		t.Errorf("Expected candidate with ID 1003, got %d", b.ID)


### PR DESCRIPTION
Fixes a storage calculation bug in `rebuild` with `storage` placement using the new contraints `SelectBroker` method.