### PR TITLE
Jamie/auto brokers

### DIFF
--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -73,11 +73,12 @@ Usage:
   topicmappr rebuild [flags]
 
 Flags:
-      --brokers string                Broker list to scope all partition placements to
+      --brokers string                Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)
       --force-rebuild                 Forces a complete map rebuild
   -h, --help                          help for rebuild
       --map-string string             Rebuild a partition map provided as a string literal
       --metrics-age int               Kafka metrics age tolerance (in minutes) (when using storage placement) (default 60)
+      --min-rack-ids int              Minimum number of required of unique rack IDs per replica set (0 requires that all are unique)
       --optimize string               Optimization priority for the storage placement strategy: [distribution, storage] (default "distribution")
       --out-file string               If defined, write a combined map of all topics to a file
       --out-path string               Path to write output map files to
@@ -105,7 +106,7 @@ Usage:
   topicmappr rebalance [flags]
 
 Flags:
-      --brokers string                 Broker list to scope all partition placements to
+      --brokers string                 Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)
   -h, --help                           help for rebalance
       --locality-scoped                Disallow a relocation to traverse rack.id values among brokers
       --metrics-age int                Kafka metrics age tolerance (in minutes) (default 60)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -23,7 +23,7 @@ func init() {
 	rebalanceCmd.Flags().String("topics", "", "Rebuild topics (comma delim. list) by lookup in ZooKeeper")
 	rebalanceCmd.Flags().String("out-path", "", "Path to write output map files to")
 	rebalanceCmd.Flags().String("out-file", "", "If defined, write a combined map of all topics to a file")
-	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to")
+	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)")
 	rebalanceCmd.Flags().Float64("storage-threshold", 0.20, "Percent below the harmonic mean storage free to target for partition offload (0 targets a brokers)")
 	rebalanceCmd.Flags().Float64("storage-threshold-gb", 0.00, "Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold")
 	rebalanceCmd.Flags().Float64("tolerance", 0.10, "Percent distance from the mean storage free to limit storage scheduling")

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -36,7 +36,7 @@ func init() {
 	rebuildCmd.Flags().Int("min-rack-ids", 0, "Minimum number of required of unique rack IDs per replica set (0 requires that all are unique)")
 	rebuildCmd.Flags().String("optimize", "distribution", "Optimization priority for the storage placement strategy: [distribution, storage]")
 	rebuildCmd.Flags().Float64("partition-size-factor", 1.0, "Factor by which to multiply partition sizes when using storage placement")
-	rebuildCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to")
+	rebuildCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)")
 	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")

--- a/kafkazk/brokers_test.go
+++ b/kafkazk/brokers_test.go
@@ -196,6 +196,21 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdateIncludeExisting(t *testing.T) {
+	zk := &Mock{}
+	bmm, _ := zk.GetAllBrokerMeta(false)
+	bm := newMockBrokerMap()
+
+	bm.Update([]int{-1}, bmm)
+
+	// Ensure all broker IDs are in the map.
+	for _, id := range []int{StubBrokerID, 1001, 1002, 1003, 1004} {
+		if _, ok := bm[id]; !ok {
+			t.Errorf("Expected presence of ID %d", id)
+		}
+	}
+}
+
 func TestSubStorageAll(t *testing.T) {
 	bm := newMockBrokerMap()
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))


### PR DESCRIPTION
Updates the `--brokers` flag to accept the special identifier `-1` which automatically expands to an ID list of all mapped brokers.

Example: If `topic1`  were running on broker set `1001,1002,1003` and we wanted to perform a rebalance, we might run the command `topicmappr rebalance --topics topic1 --brokers 1001,1002,1003`. This requires users to look up which brokers held partitions for `topic1`. Specifying `-1` will automatically expand to `1001,1002,1003` without a user having to find this information: `topicmappr rebalance --topics topic1 --brokers -1` would result in the exact same output.

Additionally, this expansion is an in-place substitution only for the special identifier. This allows additional, unmapped brokers to be included. If we were to scale `topic1` using the original brokers along with the additional brokers `1004,1005`, we could use the following command: `topicmappr rebalance --topics topic1 --brokers -1,1004,1005`.

Closes #163 