### PR TITLE
iterative rebalance tolerance

### DIFF
--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -117,7 +117,7 @@ Flags:
       --partition-size-threshold int   Size in megabytes where partitions below this value will not be moved in a rebalance (default 512)
       --storage-threshold float        Percent below the harmonic mean storage free to target for partition offload (0 targets a brokers) (default 0.2)
       --storage-threshold-gb float     Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold
-      --tolerance float                Percent distance from the mean storage free to limit storage scheduling (default 0.1)
+      --tolerance float                Percent distance from the mean storage free to limit storage scheduling (0 performs automatic tolerance selection)
       --topics string                  Rebuild topics (comma delim. list) by lookup in ZooKeeper
       --verbose                        Verbose output
       --zk-metrics-prefix string       ZooKeeper namespace prefix for Kafka metrics (default "topicmappr")

--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	indent = "\x20\x20"
-	div    = 1073741824.00
+	div    = 1 << 30
 )
 
 var (

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -167,7 +167,14 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	// Sort the rebalance results by range ascending.
 	sort.Slice(resultsByRange, func(i, j int) bool {
-		return resultsByRange[i].storageRange < resultsByRange[j].storageRange
+		switch{
+		case resultsByRange[i].storageRange < resultsByRange[j].storageRange:
+			return true
+		case resultsByRange[i].storageRange > resultsByRange[j].storageRange:
+			return false
+		}
+
+		return resultsByRange[i].tolerance < resultsByRange[j].tolerance
 	})
 
 	// Chose the results with the lowest range.

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -88,7 +88,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	// of rebalance plans. A rebalanceResults holds
 	// any relevant output along with metadata that
 	// hints at the quality of the output, such as
-	// the resulting storage utlization range.
+	// the resulting storage utilization range.
 	type rebalanceResults struct {
 		storageRange float64
 		tolerance    float64
@@ -107,7 +107,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 		tolFlag, _ := cmd.Flags().GetFloat64("tolerance")
 		var tol float64
 
-		if tolFlag != 0.00 {
+		if tolFlag == 0.00 {
 			tol = i
 		} else {
 			tol = tolFlag
@@ -155,7 +155,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 		// Populate the output.
 		resultsByRange = append(resultsByRange, rebalanceResults{
 			storageRange: params.brokers.StorageRange(),
-			tolerance:    i,
+			tolerance:    tol,
 			partitionMap: partitionMap,
 			relocations:  params.relos,
 			brokers:      params.brokers,
@@ -167,18 +167,17 @@ func rebalance(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	// Sort the rebalance results by range ascending.
 	sort.Slice(resultsByRange, func(i, j int) bool {
 		return resultsByRange[i].storageRange < resultsByRange[j].storageRange
 	})
 
+	// Chose the results with the lowest range.
 	m := resultsByRange[0]
 	partitionMap, relos, brokers := m.partitionMap, m.relocations, m.brokers
 
-	fmt.Printf("xxx using a tolerance of %f\n", m.tolerance)
-
-	for i := range resultsByRange {
-		fmt.Printf("range for map %d: %f\n", i, resultsByRange[i].storageRange)
-	}
+	// Print parameters used for rebalance decisions.
+	printRebalanceParams(cmd, brokersOrig, m.tolerance)
 
 	// Print planned relocations.
 	printPlannedRelocations(offloadTargets, relos, partitionMeta)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -17,6 +17,19 @@ var rebalanceCmd = &cobra.Command{
 	Run:   rebalance,
 }
 
+// Rebalance may be configured to run a series
+// of rebalance plans. A rebalanceResults holds
+// any relevant output along with metadata that
+// hints at the quality of the output, such as
+// the resulting storage utilization range.
+type rebalanceResults struct {
+	storageRange float64
+	tolerance    float64
+	partitionMap *kafkazk.PartitionMap
+	relocations  map[int][]relocation
+	brokers      kafkazk.BrokerMap
+}
+
 func init() {
 	rootCmd.AddCommand(rebalanceCmd)
 
@@ -80,19 +93,6 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	otm := map[int]struct{}{}
 	for _, id := range offloadTargets {
 		otm[id] = struct{}{}
-	}
-
-	// Rebalance may be configured to run a series
-	// of rebalance plans. A rebalanceResults holds
-	// any relevant output along with metadata that
-	// hints at the quality of the output, such as
-	// the resulting storage utilization range.
-	type rebalanceResults struct {
-		storageRange float64
-		tolerance    float64
-		partitionMap *kafkazk.PartitionMap
-		relocations  map[int][]relocation
-		brokers      kafkazk.BrokerMap
 	}
 
 	resultsByRange := []rebalanceResults{}
@@ -175,7 +175,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	partitionMapOut, brokersOut, relos := m.partitionMap, m.brokers, m.relocations
 
 	// Print parameters used for rebalance decisions.
-	printRebalanceParams(cmd, brokersIn, m.tolerance)
+	printRebalanceParams(cmd, resultsByRange, brokersIn, m.tolerance)
 
 	// Print planned relocations.
 	printPlannedRelocations(offloadTargets, relos, partitionMeta)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -26,7 +26,7 @@ func init() {
 	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)")
 	rebalanceCmd.Flags().Float64("storage-threshold", 0.20, "Percent below the harmonic mean storage free to target for partition offload (0 targets a brokers)")
 	rebalanceCmd.Flags().Float64("storage-threshold-gb", 0.00, "Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold")
-	rebalanceCmd.Flags().Float64("tolerance", 0.0, "Percent distance from the mean storage free to limit storage scheduling (0 performs automatic tolerance configuration)")
+	rebalanceCmd.Flags().Float64("tolerance", 0.0, "Percent distance from the mean storage free to limit storage scheduling (0 performs automatic tolerance selection)")
 	rebalanceCmd.Flags().Int("partition-limit", 30, "Limit the number of top partitions by size eligible for relocation per broker")
 	rebalanceCmd.Flags().Int("partition-size-threshold", 512, "Size in megabytes where partitions below this value will not be moved in a rebalance")
 	rebalanceCmd.Flags().Bool("locality-scoped", false, "Disallow a relocation to traverse rack.id values among brokers")

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -216,7 +216,7 @@ func printRebalanceParams(cmd *cobra.Command, results []rebalanceResults, broker
 		fmt.Printf("%s-\n%sTop 10 rebalance map results\n", indent, indent)
 		for i := range results {
 			fmt.Printf("%stolerance: %.2f -> range: %.2fGB\n",
-				indent, results[i].tolerance, results[i].storageRange)
+				indent, results[i].tolerance, results[i].storageRange/div)
 			if i == 10 {
 				break
 			}
@@ -256,8 +256,8 @@ func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBroke
 	}
 
 	if verbose {
-		fmt.Printf("\n[pass %d] Broker %d has a storage free of %.2fGB. Top partitions:\n",
-			params.pass, sourceID, brokers[sourceID].StorageFree/div)
+		fmt.Printf("\n[pass %d with tolerance %.2f] Broker %d has a storage free of %.2fGB. Top partitions:\n",
+			params.pass, tolerance, sourceID, brokers[sourceID].StorageFree/div)
 
 		for _, p := range topPartn {
 			pSize, _ := partitionMeta.Size(p)

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -174,25 +174,6 @@ func validateBrokersForRebalance(cmd *cobra.Command, brokers kafkazk.BrokerMap, 
 		}
 	}
 
-	// Print rebalance parameters as a result of
-	// input configurations and brokers found
-	// to be beyond the storage threshold.
-	fmt.Println("\nRebalance parameters:")
-
-	tol, _ := cmd.Flags().GetFloat64("tolerance")
-	pst, _ := cmd.Flags().GetInt("partition-size-threshold")
-	mean, hMean := brokers.Mean(), brokers.HMean()
-
-	fmt.Printf("%sIgnoring partitions smaller than %dMB\n", indent, pst)
-	fmt.Printf("%sFree storage mean, harmonic mean: %.2fGB, %.2fGB\n",
-		indent, mean/div, hMean/div)
-
-	fmt.Printf("%sBroker free storage limits (with a %.2f%% tolerance from mean):\n",
-		indent, tol*100)
-
-	fmt.Printf("%s%sSources limited to <= %.2fGB\n", indent, indent, mean*(1+tol)/div)
-	fmt.Printf("%s%sDestinations limited to >= %.2fGB\n", indent, indent, mean*(1-tol)/div)
-
 	fmt.Printf("\n%s:\n", selectorMethod.String())
 
 	// Exit if no target brokers were found.
@@ -206,6 +187,26 @@ func validateBrokersForRebalance(cmd *cobra.Command, brokers kafkazk.BrokerMap, 
 	}
 
 	return offloadTargets
+}
+
+func printRebalanceParams(cmd *cobra.Command, brokers kafkazk.BrokerMap, tol float64) {
+	// Print rebalance parameters as a result of
+	// input configurations and brokers found
+	// to be beyond the storage threshold.
+	fmt.Println("\nRebalance parameters:")
+
+	pst, _ := cmd.Flags().GetInt("partition-size-threshold")
+	mean, hMean := brokers.Mean(), brokers.HMean()
+
+	fmt.Printf("%sIgnoring partitions smaller than %dMB\n", indent, pst)
+	fmt.Printf("%sFree storage mean, harmonic mean: %.2fGB, %.2fGB\n",
+		indent, mean/div, hMean/div)
+
+	fmt.Printf("%sBroker free storage limits (with a %.2f%% tolerance from mean):\n",
+		indent, tol*100)
+
+	fmt.Printf("%s%sSources limited to <= %.2fGB\n", indent, indent, mean*(1+tol)/div)
+	fmt.Printf("%s%sDestinations limited to >= %.2fGB\n", indent, indent, mean*(1-tol)/div)
 }
 
 func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBrokerParams) int {

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -53,6 +53,7 @@ type planRelocationsForBrokerParams struct {
 	topPartitionsLimit     int
 	partitionSizeThreshold int
 	offloadTargetsMap      map[int]struct{}
+	tolerance              float64
 }
 
 // relocationPlan is a mapping of topic,
@@ -209,7 +210,6 @@ func validateBrokersForRebalance(cmd *cobra.Command, brokers kafkazk.BrokerMap, 
 
 func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBrokerParams) int {
 	verbose, _ := cmd.Flags().GetBool("verbose")
-	tolerance, _ := cmd.Flags().GetFloat64("tolerance")
 	localityScoped, _ := cmd.Flags().GetBool("locality-scoped")
 
 	relos := params.relos
@@ -221,6 +221,7 @@ func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBroke
 	topPartitionsLimit := params.topPartitionsLimit
 	partitionSizeThreshold := float64(params.partitionSizeThreshold * 1048576)
 	offloadTargetsMap := params.offloadTargetsMap
+	tolerance := params.tolerance
 
 	// Use the arithmetic mean for target
 	// thresholds.


### PR DESCRIPTION
Adds automatic `tolerance` selection to the `rebalance` subcommand. This works by iteratively computing maps for all possible tolerance values in increments of 1% and storing results for each value. The result that is most optimal is automatically selected.

Closes #252. 