### PR TITLE
updated relocation planner to avoid early returns in broker selection…

### DIFF
--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -167,7 +167,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	// Sort the rebalance results by range ascending.
 	sort.Slice(resultsByRange, func(i, j int) bool {
-		switch{
+		switch {
 		case resultsByRange[i].storageRange < resultsByRange[j].storageRange:
 			return true
 		case resultsByRange[i].storageRange > resultsByRange[j].storageRange:


### PR DESCRIPTION
Updated the relocation planner to avoid early returns in broker selection exhaustion. When iterating over partitions to consider relocating, if no suitable destination brokers exist, the whole planning phase for the broker is concluded for the iteration. This prematurely limits relocation plans and possibly prevents would-be relocations all together.