### PR TITLE
automatic tolerance considers std. dev.

### DIFF
--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -25,6 +25,7 @@ var rebalanceCmd = &cobra.Command{
 // the resulting storage utilization range.
 type rebalanceResults struct {
 	storageRange float64
+	stdDev       float64
 	tolerance    float64
 	partitionMap *kafkazk.PartitionMap
 	relocations  map[int][]relocation
@@ -162,6 +163,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 			// Insert the rebalanceResults.
 			results <- rebalanceResults{
 				storageRange: params.brokers.StorageRange(),
+				stdDev:       params.brokers.StorageStdDev(),
 				tolerance:    tol,
 				partitionMap: partitionMap,
 				relocations:  params.relos,
@@ -194,7 +196,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 			return false
 		}
 
-		return resultsByRange[i].tolerance < resultsByRange[j].tolerance
+		return resultsByRange[i].stdDev < resultsByRange[j].stdDev
 	})
 
 	// Chose the results with the lowest range.

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -214,9 +214,9 @@ func printRebalanceParams(cmd *cobra.Command, results []rebalanceResults, broker
 	// in verbose.
 	if verbose {
 		fmt.Printf("%s-\n%sTop 10 rebalance map results\n", indent, indent)
-		for i := range results {
-			fmt.Printf("%stolerance: %.2f -> range: %.2fGB\n",
-				indent, results[i].tolerance, results[i].storageRange/div)
+		for i, r := range results {
+			fmt.Printf("%stolerance: %.2f -> range: %.2fGB, std. deviation: %.2fGB\n",
+				indent, r.tolerance, r.storageRange/div, r.stdDev/div)
 			if i == 10 {
 				break
 			}


### PR DESCRIPTION
Adds a multi-level sort to the automatic tolerance selector. Results are sorted by range then standard deviation. This adds an additional quality dimension to what is considered the most optimal result.

Top results in `verbose` show the additional metric:

```
  Top 10 rebalance map results
  tolerance: 0.11 -> range: 382.79GB, std. deviation: 103.56GB
  tolerance: 0.13 -> range: 382.79GB, std. deviation: 104.00GB
  tolerance: 0.08 -> range: 388.49GB, std. deviation: 103.90GB
  tolerance: 0.12 -> range: 388.49GB, std. deviation: 104.27GB
  tolerance: 0.07 -> range: 388.49GB, std. deviation: 104.35GB
  tolerance: 0.05 -> range: 388.49GB, std. deviation: 104.79GB
  tolerance: 0.14 -> range: 388.49GB, std. deviation: 105.69GB
  tolerance: 0.16 -> range: 395.80GB, std. deviation: 107.28GB
  tolerance: 0.17 -> range: 406.89GB, std. deviation: 108.41GB
  tolerance: 0.15 -> range: 409.49GB, std. deviation: 106.00GB
  tolerance: 0.09 -> range: 411.33GB, std. deviation: 104.95GB
```

Closes #255.