### PR TITLE
jamie/leadership-optimization

### DIFF
--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -80,6 +80,7 @@ Flags:
       --metrics-age int               Kafka metrics age tolerance (in minutes) (when using storage placement) (default 60)
       --min-rack-ids int              Minimum number of required of unique rack IDs per replica set (0 requires that all are unique)
       --optimize string               Optimization priority for the storage placement strategy: [distribution, storage] (default "distribution")
+      --optimize-leaders              Perform a leadership optimization
       --out-file string               If defined, write a combined map of all topics to a file
       --out-path string               Path to write output map files to
       --partition-size-factor float   Factor by which to multiply partition sizes when using storage placement (default 1)
@@ -110,7 +111,7 @@ Flags:
   -h, --help                           help for rebalance
       --locality-scoped                Disallow a relocation to traverse rack.id values among brokers
       --metrics-age int                Kafka metrics age tolerance (in minutes) (default 60)
-      --optimize-leaders               Perform a naive leadership optimization
+      --optimize-leaders               Perform a leadership optimization
       --out-file string                If defined, write a combined map of all topics to a file
       --out-path string                Path to write output map files to
       --partition-limit int            Limit the number of top partitions by size eligible for relocation per broker (default 30)

--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -80,7 +80,7 @@ Flags:
       --metrics-age int               Kafka metrics age tolerance (in minutes) (when using storage placement) (default 60)
       --min-rack-ids int              Minimum number of required of unique rack IDs per replica set (0 requires that all are unique)
       --optimize string               Optimization priority for the storage placement strategy: [distribution, storage] (default "distribution")
-      --optimize-leaders              Perform a leadership optimization
+      --optimize-leadership           Rebalance all broker leader/follower ratios
       --out-file string               If defined, write a combined map of all topics to a file
       --out-path string               Path to write output map files to
       --partition-size-factor float   Factor by which to multiply partition sizes when using storage placement (default 1)
@@ -111,7 +111,7 @@ Flags:
   -h, --help                           help for rebalance
       --locality-scoped                Disallow a relocation to traverse rack.id values among brokers
       --metrics-age int                Kafka metrics age tolerance (in minutes) (default 60)
-      --optimize-leaders               Perform a leadership optimization
+      --optimize-leadership            Rebalance all broker leader/follower ratios
       --out-file string                If defined, write a combined map of all topics to a file
       --out-path string                Path to write output map files to
       --partition-limit int            Limit the number of top partitions by size eligible for relocation per broker (default 30)

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -78,7 +78,7 @@ func printBrokerAssignmentStats(cmd *cobra.Command, pm1, pm2 *kafkazk.PartitionM
 	fmt.Printf("%s-\n", indent)
 
 	// Per-broker info.
-	UseStats := pm2.UseStats()
+	UseStats := pm2.UseStats().List()
 	for _, use := range UseStats {
 		fmt.Printf("%sBroker %d - leader: %d, follower: %d, total: %d\n",
 			indent, use.ID, use.Leader, use.Follower, use.Leader+use.Follower)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -48,7 +48,7 @@ func init() {
 	rebalanceCmd.Flags().Bool("verbose", false, "Verbose output")
 	rebalanceCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
 	rebalanceCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes)")
-	rebalanceCmd.Flags().Bool("optimize-leaders", false, "Perform a leadership optimization")
+	rebalanceCmd.Flags().Bool("optimize-leadership", false, "Rebalance all broker leader/follower ratios")
 
 	// Required.
 	rebalanceCmd.MarkFlagRequired("brokers")

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -48,7 +48,7 @@ func init() {
 	rebalanceCmd.Flags().Bool("verbose", false, "Verbose output")
 	rebalanceCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
 	rebalanceCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes)")
-	rebalanceCmd.Flags().Bool("optimize-leaders", false, "Perform a naive leadership optimization")
+	rebalanceCmd.Flags().Bool("optimize-leaders", false, "Perform a leadership optimization")
 
 	// Required.
 	rebalanceCmd.MarkFlagRequired("brokers")

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -431,7 +431,7 @@ func applyRelocationPlan(cmd *cobra.Command, pm *kafkazk.PartitionMap, plan relo
 
 	// Optimize leaders.
 	if t, _ := cmd.Flags().GetBool("optimize-leaders"); t {
-		pm.SimpleLeaderOptimization()
+		pm.OptimizeLeaderFollower()
 	}
 }
 

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -430,7 +430,7 @@ func applyRelocationPlan(cmd *cobra.Command, pm *kafkazk.PartitionMap, plan relo
 	}
 
 	// Optimize leaders.
-	if t, _ := cmd.Flags().GetBool("optimize-leaders"); t {
+	if t, _ := cmd.Flags().GetBool("optimize-leadership"); t {
 		pm.OptimizeLeaderFollower()
 	}
 }

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -40,6 +40,7 @@ func init() {
 	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")
+	rebuildCmd.Flags().Bool("optimize-leaders", false, "Perform a naive leadership optimization")
 
 	// Required.
 	rebuildCmd.MarkFlagRequired("brokers")
@@ -155,6 +156,11 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	// Build a new map using the provided list of brokers.
 	// This is OK to run even when a no-op is intended.
 	partitionMapOut, errs := buildMap(cmd, partitionMapIn, partitionMeta, brokers, affinities)
+
+	// Optimize leaders.
+	if t, _ := cmd.Flags().GetBool("optimize-leaders"); t {
+		partitionMapOut.SimpleLeaderOptimization()
+	}
 
 	// Count missing brokers as a warning.
 	if bs.Missing > 0 {

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -159,7 +159,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 
 	// Optimize leaders.
 	if t, _ := cmd.Flags().GetBool("optimize-leaders"); t {
-		partitionMapOut.SimpleLeaderOptimization()
+		partitionMapOut.OptimizeLeaderFollower()
 	}
 
 	// Count missing brokers as a warning.

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -40,7 +40,7 @@ func init() {
 	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")
-	rebuildCmd.Flags().Bool("optimize-leaders", false, "Perform a leadership optimization")
+	rebuildCmd.Flags().Bool("optimize-leadership", false, "Rebalance all broker leader/follower ratios")
 
 	// Required.
 	rebuildCmd.MarkFlagRequired("brokers")
@@ -158,7 +158,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	partitionMapOut, errs := buildMap(cmd, partitionMapIn, partitionMeta, brokers, affinities)
 
 	// Optimize leaders.
-	if t, _ := cmd.Flags().GetBool("optimize-leaders"); t {
+	if t, _ := cmd.Flags().GetBool("optimize-leadership"); t {
 		partitionMapOut.OptimizeLeaderFollower()
 	}
 

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -40,7 +40,7 @@ func init() {
 	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")
-	rebuildCmd.Flags().Bool("optimize-leaders", false, "Perform a naive leadership optimization")
+	rebuildCmd.Flags().Bool("optimize-leaders", false, "Perform a leadership optimization")
 
 	// Required.
 	rebuildCmd.MarkFlagRequired("brokers")

--- a/kafkazk/brokers.go
+++ b/kafkazk/brokers.go
@@ -50,6 +50,22 @@ type BrokerUseStats struct {
 	Follower int
 }
 
+// BrokerUseStatsList is a map of IDs to *BrokerUseStats.
+type BrokerUseStatsMap map[int]*BrokerUseStats
+
+// List returns a BrokerUseStatsList from a BrokerUseStatsMap.
+func (b BrokerUseStatsMap) List() BrokerUseStatsList {
+	var l BrokerUseStatsList
+
+	for _, s := range b {
+		l = append(l, s)
+	}
+
+	sort.Sort(l)
+
+	return l
+}
+
 // BrokerUseStatsList is a slice of *BrokerUseStats.
 type BrokerUseStatsList []*BrokerUseStats
 

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -157,11 +157,13 @@ func NewRebuildParams() RebuildParams {
 // go further down the replica list. This ratio is recalculated at each
 // replica set visited to avoid extreme skew.
 func (pm *PartitionMap) OptimizeLeaderFollower() {
-	for _, partn := range pm.Partitions {
-		sort.Sort(replicasByLeaderFollowerRatio{
-			replicas: partn.Replicas,
-			stats:    pm.UseStats(),
-		})
+	for i := 0; i < len(pm.Partitions[0].Replicas); i++ {
+		for _, partn := range pm.Partitions {
+			sort.Sort(replicasByLeaderFollowerRatio{
+				replicas: partn.Replicas,
+				stats:    pm.UseStats(),
+			})
+		}
 	}
 }
 

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -150,13 +150,13 @@ func NewRebuildParams() RebuildParams {
 	}
 }
 
-// SimpleLeaderOptimization is a naive leadership optimization algorithm
-// that iterates over each partition's replica list and sorts brokers
+// OptimizeLeaderFollower is a simple leadership optimization algorithm
+// that iterates over each partition's replica set and sorts brokers
 // according to their leader/follower position ratio, ascending. The idea
 // is that if a broker has a high leader/follower ratio, it should
 // go further down the replica list. This ratio is recalculated at each
 // replica set visited to avoid extreme skew.
-func (pm *PartitionMap) SimpleLeaderOptimization() {
+func (pm *PartitionMap) OptimizeLeaderFollower() {
 	for _, partn := range pm.Partitions {
 		sort.Sort(replicasByLeaderFollowerRatio{
 			replicas: partn.Replicas,

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -92,11 +92,21 @@ func (r replicasByLeaderFollowerRatio) Less(i, j int) bool {
 	id1 := r.replicas[i]
 	id2 := r.replicas[j]
 
-	if r.stats[id1].Follower == 0 || r.stats[id2].Follower == 0 {
+	switch {
+	// Neither broker holds follower positions, compare
+	// leadership counts.
+	case r.stats[id1].Follower == 0 && r.stats[id2].Follower == 0:
 		return r.stats[id1].Leader < r.stats[id2].Leader
+	// i ratio == ∞
+	case r.stats[id1].Follower == 0:
+		return false
+	// j ratio == ∞
+	case r.stats[id2].Follower == 0:
+		return true
+	// We have a comparable ratio.
+	default:
+		return r.stats[id1].Leader/r.stats[id1].Follower < r.stats[id2].Leader/r.stats[id2].Follower
 	}
-
-	return r.stats[id1].Leader/r.stats[id1].Follower < r.stats[id2].Leader/r.stats[id2].Follower
 }
 
 // PartitionMeta holds partition metadata.

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -93,7 +93,7 @@ func (r replicasByLeaderFollowerRatio) Less(i, j int) bool {
 	id2 := r.replicas[j]
 
 	if r.stats[id1].Follower == 0 || r.stats[id2].Follower == 0 {
-		return r.stats[id1].Leader > r.stats[id2].Leader
+		return r.stats[id1].Leader < r.stats[id2].Leader
 	}
 
 	return r.stats[id1].Leader/r.stats[id1].Follower < r.stats[id2].Leader/r.stats[id2].Follower

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -294,7 +294,7 @@ func TestStrip(t *testing.T) {
 func TestUseStats(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
 
-	s := pm.UseStats()
+	s := pm.UseStats().List()
 
 	expected := map[int][2]int{
 		1001: [2]int{1, 2},


### PR DESCRIPTION
This PR adds the `--optimize-leaders` option to the `rebuild` sub-command.

Further, it improves (_replaces_) the `SimpleLeaderOptimization` function by visiting each partition replica set and sorting brokers ascending by their leader/follower ratio with a recalculation at each replica set visit.

Using a real-world partition map that was previously storage rebalanced but not leadership optimized, the starting leader/follower count for each broker is as follows:

```
  Broker 1737 - leader: 6, follower: 6, total: 12
  Broker 1739 - leader: 8, follower: 5, total: 13
  Broker 1743 - leader: 4, follower: 2, total: 6
  Broker 1745 - leader: 17, follower: 19, total: 36
  Broker 1746 - leader: 14, follower: 15, total: 29
  Broker 1752 - leader: 9, follower: 17, total: 26
  Broker 1754 - leader: 4, follower: 11, total: 15
  Broker 1755 - leader: 15, follower: 11, total: 26
  Broker 1756 - leader: 10, follower: 10, total: 20
  Broker 1759 - leader: 10, follower: 14, total: 24
  Broker 1760 - leader: 26, follower: 19, total: 45
  Broker 1763 - leader: 4, follower: 5, total: 9
  Broker 1764 - leader: 8, follower: 11, total: 19
  Broker 1767 - leader: 2, follower: 6, total: 8
  Broker 1768 - leader: 20, follower: 14, total: 34
  Broker 1770 - leader: 12, follower: 12, total: 24
  Broker 1792 - leader: 8, follower: 6, total: 14
  Broker 1860 - leader: 12, follower: 6, total: 18
  Broker 1872 - leader: 15, follower: 16, total: 31
  Broker 1873 - leader: 14, follower: 11, total: 25
  Broker 1874 - leader: 19, follower: 17, total: 36
  Broker 1876 - leader: 16, follower: 20, total: 36
  Broker 1962 - leader: 3, follower: 3, total: 6
```

Notice broker `1768` and `1754` as having extreme differences in their leadership vs follower roles. When passing this map through the new `SimpleLeaderOptimization`, we see far better ratios (nearly optimal in all cases) across the board:

```
  Broker 1737 - leader: 6, follower: 6, total: 12
  Broker 1739 - leader: 6, follower: 7, total: 13
  Broker 1743 - leader: 3, follower: 3, total: 6
  Broker 1745 - leader: 18, follower: 18, total: 36
  Broker 1746 - leader: 14, follower: 15, total: 29
  Broker 1752 - leader: 13, follower: 13, total: 26
  Broker 1754 - leader: 8, follower: 7, total: 15
  Broker 1755 - leader: 13, follower: 13, total: 26
  Broker 1756 - leader: 10, follower: 10, total: 20
  Broker 1759 - leader: 12, follower: 12, total: 24
  Broker 1760 - leader: 23, follower: 22, total: 45
  Broker 1763 - leader: 5, follower: 4, total: 9
  Broker 1764 - leader: 10, follower: 9, total: 19
  Broker 1767 - leader: 4, follower: 4, total: 8
  Broker 1768 - leader: 17, follower: 17, total: 34
  Broker 1770 - leader: 11, follower: 13, total: 24
  Broker 1792 - leader: 7, follower: 7, total: 14
  Broker 1860 - leader: 9, follower: 9, total: 18
  Broker 1872 - leader: 16, follower: 15, total: 31
  Broker 1873 - leader: 13, follower: 12, total: 25
  Broker 1874 - leader: 18, follower: 18, total: 36
  Broker 1876 - leader: 18, follower: 18, total: 36
  Broker 1962 - leader: 2, follower: 4, total: 6
```

Note: the difference in total partition counts per-broker is ok; this is an expected result of storage rebalancing where not all partitions are equal in size.