### PR TITLE
jamie/ttl throttle

### DIFF
--- a/cmd/autothrottle/api.go
+++ b/cmd/autothrottle/api.go
@@ -66,17 +66,18 @@ func getThrottle(w http.ResponseWriter, req *http.Request, zk kafkazk.Handler, p
 		return
 	}
 
-	t, err := zk.Get(p)
+	r, err := getThrottleOverride(zk, p)
 	if err != nil {
-		io.WriteString(w, fmt.Sprintf("Error getting throttle: %s\n", err.Error()))
+		io.WriteString(w, err.Error())
 		return
 	}
 
-	switch string(t) {
-	case "":
-		io.WriteString(w, "No throttle is set\n")
+	switch r.Rate {
+	case 0:
+		io.WriteString(w, "no throttle override is set\n")
 	default:
-		resp := fmt.Sprintf("A throttle override is configured at %sMB/s\n", t)
+		resp := fmt.Sprintf("a throttle override is configured at %dMB/s, auto-clear==%v\n",
+			r.Rate, r.AutoClear)
 		io.WriteString(w, resp)
 	}
 }
@@ -89,23 +90,51 @@ func setThrottle(w http.ResponseWriter, req *http.Request, zk kafkazk.Handler, p
 		return
 	}
 
-	rate := req.URL.Query().Get("rate")
+	// Get rate param.
 
-	if rate == "" {
-		io.WriteString(w, "Rate param must be supplied\n")
+	r := req.URL.Query().Get("rate")
+	var rate int
+	var err error
+
+	rate, err = strconv.Atoi(r)
+
+	switch {
+	case r == "":
+		io.WriteString(w, "rate param must be supplied\n")
+		return
+	case r == "0":
+		io.WriteString(w, "rate param must be >0\n")
+		return
+	case err != nil:
+		io.WriteString(w, "rate param must be supplied as an integer\n")
 		return
 	}
 
-	if _, err := strconv.Atoi(rate); err != nil {
-		io.WriteString(w, "Rate param must be supplied as an integer\n")
-		return
+	// Get automatic rate removal param.
+
+	c := req.URL.Query().Get("clear")
+	var clear bool
+
+	if c != "" {
+		clear, err = strconv.ParseBool(c)
+		if err != nil {
+			io.WriteString(w, "clear param must be a bool\n")
+			return
+		}
 	}
 
-	err := zk.Set(p, rate)
+	// Populate configs.
+
+	rateCfg := ThrottleOverrideConfig{
+		Rate:      rate,
+		AutoClear: clear,
+	}
+
+	err = setThrottleOverride(zk, p, rateCfg)
 	if err != nil {
-		io.WriteString(w, fmt.Sprintf("Error setting throttle: %s\n", err))
+		io.WriteString(w, err.Error())
 	} else {
-		io.WriteString(w, fmt.Sprintf("Throttle successfully set to %sMB/s\n", rate))
+		io.WriteString(w, fmt.Sprintf("throttle successfully set to %dMB/s\n", rate))
 	}
 }
 
@@ -117,11 +146,11 @@ func removeThrottle(w http.ResponseWriter, req *http.Request, zk kafkazk.Handler
 		return
 	}
 
-	err := zk.Set(p, "")
+	err := setThrottleOverride(zk, p, ThrottleOverrideConfig{Rate: 0})
 	if err != nil {
-		io.WriteString(w, fmt.Sprintf("Error setting throttle: %s\n", err))
+		io.WriteString(w, err.Error())
 	} else {
-		io.WriteString(w, "Throttle successfully removed\n")
+		io.WriteString(w, "throttle successfully removed\n")
 	}
 }
 

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -171,6 +171,8 @@ func main() {
 
 	// Run.
 	var interval int64
+	var ticker = time.NewTicker(time.Duration(Config.Interval) * time.Second)
+
 	for {
 		interval++
 		throttleMeta.topics = throttleMeta.topics[:0]
@@ -230,6 +232,7 @@ func main() {
 			knownThrottles = true
 		} else {
 			log.Println("No topics undergoing reassignment")
+
 			// Unset any throttles.
 			if knownThrottles || interval == Config.CleanupAfter {
 				// Reset the interval.
@@ -244,22 +247,21 @@ func main() {
 					// without error.
 					knownThrottles = false
 				}
+			}
 
-				// Remove any configured throttle overrides
-				// if AutoRemove is true.
-				if overrideCfg.AutoRemove {
-					err := setThrottleOverride(zk, overridePath, ThrottleOverrideConfig{})
-					if err != nil {
-						log.Println(err)
-					} else {
-						log.Println("throttle override removed")
-					}
+			// Remove any configured throttle overrides
+			// if AutoRemove is true.
+			if overrideCfg.AutoRemove {
+				err := setThrottleOverride(zk, overridePath, ThrottleOverrideConfig{})
+				if err != nil {
+					log.Println(err)
+				} else {
+					log.Println("Throttle override removed")
 				}
 			}
 		}
 
-		// Sleep for the next check interval.
-		time.Sleep(time.Second * time.Duration(Config.Interval))
+		<-ticker.C
 	}
 
 }

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -212,7 +212,7 @@ func main() {
 			log.Printf("Topics with ongoing reassignments: %s\n", throttleMeta.topics)
 
 			// Check if a throttle override is set.
-			// If so, apply that static throttle.
+			// If so, apply the static throttle.
 			p := fmt.Sprintf("/%s/%s", apiConfig.ZKPrefix, apiConfig.RateSetting)
 			overrideCfg, err := getThrottleOverride(zk, p)
 			if err != nil {
@@ -255,19 +255,19 @@ func main() {
 }
 
 func getThrottleOverride(zk kafkazk.Handler, p string) (*ThrottleOverrideConfig, error) {
+	c := &ThrottleOverrideConfig{}
+
 	override, err := zk.Get(p)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting throttle override: %s", err)
+		return c, fmt.Errorf("Error getting throttle override: %s", err)
 	}
-
-	c := &ThrottleOverrideConfig{}
 
 	if len(override) == 0 {
 		return c, nil
 	}
 
 	if err := json.Unmarshal(override, c); err != nil {
-		return nil, fmt.Errorf("Error unmarshalling override config: %s", err)
+		return c, fmt.Errorf("Error unmarshalling override config: %s", err)
 	}
 
 	return c, nil

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -263,36 +263,3 @@ func main() {
 	}
 
 }
-
-func getThrottleOverride(zk kafkazk.Handler, p string) (*ThrottleOverrideConfig, error) {
-	c := &ThrottleOverrideConfig{}
-
-	override, err := zk.Get(p)
-	if err != nil {
-		return c, fmt.Errorf("Error getting throttle override: %s", err)
-	}
-
-	if len(override) == 0 {
-		return c, nil
-	}
-
-	if err := json.Unmarshal(override, c); err != nil {
-		return c, fmt.Errorf("Error unmarshalling override config: %s", err)
-	}
-
-	return c, nil
-}
-
-func setThrottleOverride(zk kafkazk.Handler, p string, c ThrottleOverrideConfig) error {
-	d, err := json.Marshal(c)
-	if err != nil {
-		return fmt.Errorf("Error marshalling override config: %s", err)
-	}
-
-	err = zk.Set(p, string(d))
-	if err != nil {
-		return fmt.Errorf("Error setting throttle override: %s", err)
-	}
-
-	return nil
-}

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -36,7 +36,7 @@ type ThrottleOverrideConfig struct {
 	Rate int `json:"rate"`
 	// Whether the override rate should be
 	// removed when the current reassignments finish.
-	AutoClear bool `json:"autoclear"`
+	AutoRemove bool `json:"autoremove"`
 }
 
 // Failure increments the failures count


### PR DESCRIPTION
When setting an autothrottle override rate, an optional `autoremove` bool param can be specified. This indicates whether autothrottle should remove the override rate once any ongoing reassignments are finished. Typicall,  a user may specify an override rate to expedite an ongoing reassignment but may forget to remove the override rate one the reassignment is finished. The manual rate may then unexpectedly apply to future reassignments.

The new `autoremove` param defaults to false and any override rate lookups indicate as to whether an `autoremove` flag was set:

```
$ curl -XPOST "localhost:8080/set_throttle?rate=300"
throttle successfully set to 300MB/s, autoremove==false

$ curl -XPOST "localhost:8080/set_throttle?rate=200&autoremove=t"
throttle successfully set to 200MB/s, autoremove==true

$ curl "localhost:8080/get_throttle"
a throttle override is configured at 200MB/s, autoremove==true
```

At autothrottle's next check interval where all topics have finished reassigning, the override rate will be cleared:

```
...
2019/07/16 15:59:08 No topics undergoing reassignment
2019/07/16 15:59:08 throttle override removed
```

From this point on, autothrottle will now use the default, dynamic throttle that's determined using Datadog metrics.

Finally, since the override rate config format in ZooKeeper changes, it will automatically detect and migrate the legacy format (raw rate value) to the new format ([json](https://github.com/DataDog/kafka-kit/blob/f9cee47ec69c239d9b330078ec746701fc980a64/cmd/autothrottle/throttles.go#L33-L41)) upon startup:

```
$ autothrottle
2019/07/16 16:09:45 Autothrottle Running
2019/07/16 16:09:46 Throttle override config format updated
2019/07/16 16:09:46 Admin API: localhost:8080
2019/07/16 16:09:46 No topics undergoing reassignment
```

Closes #180 