### PR TITLE
jamie/pseudobroker

### DIFF
--- a/kafkazk/brokers.go
+++ b/kafkazk/brokers.go
@@ -406,6 +406,12 @@ func BrokerMapFromPartitionMap(pm *PartitionMap, bm BrokerMetaMap, force bool) B
 		// For each broker in the
 		// partition replica set.
 		for _, id := range partition.Replicas {
+			// In offline partitions, the broker ID value
+			// gets set to -1. Skip these.
+			if id == -1 {
+				continue
+			}
+
 			// If the broker isn't in the
 			// broker map, add it.
 			if bmap[id] == nil {

--- a/kafkazk/brokers_test.go
+++ b/kafkazk/brokers_test.go
@@ -335,11 +335,17 @@ func TestBrokerMapFromPartitionMap(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
 	forceRebuild := false
 
+	// Include an offline broker / value -1.
+	pm.Partitions = append(pm.Partitions, Partition{Topic: "test_topic", Partition: 4, Replicas: []int{-1}})
+
 	brokers := BrokerMapFromPartitionMap(pm, bmm, forceRebuild)
 	expected := newMockBrokerMap()
 
 	for id, b := range brokers {
+		_, exist := expected[id]
 		switch {
+		case !exist:
+			t.Errorf("Unexpected id %d", id)
 		case b.ID != expected[id].ID:
 			t.Errorf("Expected id %d, got %d for broker %d",
 				expected[id].ID, b.ID, id)


### PR DESCRIPTION
Fixes scenarios where kafka reports broker ID values of -1 during offline partitions. This results in unexpected failure modes such as autothrottle appending -1 to a throttled followers list as dynamic broker configs. This config is detected as invalid, preventing the affected broker(s) from starting.