### PR TITLE
jamie/igore pending deletes

### DIFF
--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -74,7 +74,10 @@ func getPartitionMeta(cmd *cobra.Command, zk kafkazk.Handler) kafkazk.PartitionM
 	return partitionMeta
 }
 
-func stripPendingDeletes(pm *kafkazk.PartitionMap, zk kafkazk.Handler) {
+// stripPendingDeletes takes a partition map and zk handler. It looks
+// up any topics in a pending delete state and removes them from the
+// provided partition map, returning a list of topics removed.
+func stripPendingDeletes(pm *kafkazk.PartitionMap, zk kafkazk.Handler) []string {
 	// Get pending deletions.
 	pd, err := zk.GetPendingDeletion()
 	if err != nil {
@@ -82,7 +85,7 @@ func stripPendingDeletes(pm *kafkazk.PartitionMap, zk kafkazk.Handler) {
 	}
 
 	if len(pd) == 0 {
-		return
+		return []string{}
 	}
 
 	// This is used as a set of topic names
@@ -95,12 +98,23 @@ func stripPendingDeletes(pm *kafkazk.PartitionMap, zk kafkazk.Handler) {
 
 	// Traverse the partition map and drop
 	// any pending topics.
+
 	newPL := kafkazk.PartitionList{}
+	pendingExcluded := map[string]struct{}{}
 	for _, p := range pm.Partitions {
 		if _, exists := pending[p.Topic]; !exists {
 			newPL = append(newPL, p)
+		} else {
+			pendingExcluded[p.Topic] = struct{}{}
 		}
 	}
 
 	pm.Partitions = newPL
+
+	pendingExcludedNames := []string{}
+	for t := range pendingExcluded {
+		pendingExcludedNames = append(pendingExcludedNames, t)
+	}
+
+	return pendingExcludedNames
 }

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -32,6 +32,15 @@ func printTopics(pm *kafkazk.PartitionMap) {
 	}
 }
 
+func printExcludedTopics(p []string) {
+	if len(p) > 0 {
+		fmt.Printf("\nTopics excluded due to pending deletion:\n")
+		for _, t := range p {
+			fmt.Printf("%s%s\n", indent, t)
+		}
+	}
+}
+
 // printMapChanges takes the original input PartitionMap
 // and the final output PartitionMap and prints what's changed.
 func printMapChanges(pm1, pm2 *kafkazk.PartitionMap) {

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -80,10 +80,13 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	}
 
 	// Exclude any topics that are pending deletion.
-	stripPendingDeletes(partitionMapIn, zk)
+	pending := stripPendingDeletes(partitionMapIn, zk)
 
 	// Print topics matched to input params.
 	printTopics(partitionMapIn)
+
+	// Print if any topics were excluded due to pending deletion.
+	printExcludedTopics(pending)
 
 	// Get a broker map.
 	brokersIn := kafkazk.BrokerMapFromPartitionMap(partitionMapIn, brokerMeta, false)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -79,6 +79,9 @@ func rebalance(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	// Exclude any topics that are pending deletion.
+	stripPendingDeletes(partitionMapIn, zk)
+
 	// Print topics matched to input params.
 	printTopics(partitionMapIn)
 

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -121,11 +121,14 @@ func rebuild(cmd *cobra.Command, _ []string) {
 
 	// Build a partition map either from literal map text input or by fetching the
 	// map data from ZooKeeper. Store a copy of the original.
-	partitionMapIn := getPartitionMap(cmd, zk)
+	partitionMapIn, pending := getPartitionMap(cmd, zk)
 	originalMap := partitionMapIn.Copy()
 
 	// Get a list of affected topics.
 	printTopics(partitionMapIn)
+
+	// Print if any topics were excluded due to pending deletion.
+	printExcludedTopics(pending)
 
 	brokers, bs := getBrokers(cmd, partitionMapIn, brokerMeta)
 	brokersOrig := brokers.Copy()

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -39,6 +39,10 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) *kafkazk.PartitionM
 			fmt.Println(err)
 			os.Exit(1)
 		}
+
+		// Exclude any topics that are pending deletion.
+		stripPendingDeletes(pm, zk)
+
 		return pm
 	}
 

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -19,7 +19,7 @@ import (
 // via the ---map-string flag, or, by building a map based on topic
 // config found in ZooKeeper for all topics matching input provided
 // via the --topics flag.
-func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) *kafkazk.PartitionMap {
+func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) (*kafkazk.PartitionMap, []string) {
 	ms := cmd.Flag("map-string").Value.String()
 	switch {
 	// The map was provided as text.
@@ -30,7 +30,7 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) *kafkazk.PartitionM
 			os.Exit(1)
 		}
 
-		return pm
+		return pm, []string{}
 	// Build a map using ZooKeeper metadata
 	// for all specified topics.
 	case len(Config.topics) > 0:
@@ -41,12 +41,12 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) *kafkazk.PartitionM
 		}
 
 		// Exclude any topics that are pending deletion.
-		stripPendingDeletes(pm, zk)
+		p := stripPendingDeletes(pm, zk)
 
-		return pm
+		return pm, p
 	}
 
-	return nil
+	return nil, nil
 }
 
 // getSubAffinities, if enabled via --sub-affinity, takes reference broker maps

--- a/kafkazk/zookeeper_mocks.go
+++ b/kafkazk/zookeeper_mocks.go
@@ -22,6 +22,10 @@ func (zk *Mock) GetReassignments() Reassignments {
 	return r
 }
 
+func (zk *Mock) GetPendingDeletion() ([]string, error) {
+	return []string{"deleting_topic"}, nil
+}
+
 // Create mocks Create.
 func (zk *Mock) Create(a, b string) error {
 	_, _ = a, b


### PR DESCRIPTION
When running either `rebuild` or `rebalance` against topics that are in both a pending delete state and have offline partitions, unexpected errors occur. For instance, a `rebalance` may error out indicating that broker removals are not allowed.

This PR looks up topics in a pending deletion state. When a `rebuild` or `rebalance` command is called, if any matching topics referenced in the command are in a pending deletion state, they're excluded from any further processing.  An additional entry in the topicmappr output specifies any topics that were excluded.