### PR TITLE
jamie/info

### DIFF
--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -156,6 +156,12 @@ func printBrokerAssignmentStats(cmd *cobra.Command, pm1, pm2 *kafkazk.PartitionM
 		sd1, sd2 := mb1.StorageStdDev(), mb2.StorageStdDev()
 		fmt.Printf("%sstd. deviation: %.2fGB -> %.2fGB\n", indent, sd1/div, sd2/div)
 
+		// Storage min/max before/after.
+		min1, max1 := mb1.MinMax()
+		min2, max2 := mb2.MinMax()
+		fmt.Printf("%smin-max: %.2fGB, %.2fGB -> %.2fGB, %.2fGB\n",
+			indent, min1/div, max1/div, min2/div, max2/div)
+
 		fmt.Printf("%s-\n", indent)
 
 		// Get changes in storage utilization.

--- a/kafkazk/stats.go
+++ b/kafkazk/stats.go
@@ -119,7 +119,7 @@ func (b BrokerMap) StorageDiff(b2 BrokerMap) map[int][2]float64 {
 // StorageRangeSpread returns the range spread
 // of free storage for all brokers in the BrokerMap.
 func (b BrokerMap) StorageRangeSpread() float64 {
-	l, h := b.minMax()
+	l, h := b.MinMax()
 	// Return range spread.
 	return (h - l) / l * 100
 }
@@ -127,12 +127,12 @@ func (b BrokerMap) StorageRangeSpread() float64 {
 // StorageRange returns the range of free
 // storage for all brokers in the BrokerMap.
 func (b BrokerMap) StorageRange() float64 {
-	l, h := b.minMax()
+	l, h := b.MinMax()
 	// Return range.
 	return h - l
 }
 
-func (b BrokerMap) minMax() (float64, float64) {
+func (b BrokerMap) MinMax() (float64, float64) {
 	// Get the high/low StorageFree values.
 	h, l := 0.00, math.MaxFloat64
 


### PR DESCRIPTION
Adds storage min-max to broker summary output:

```
Storage free change estimations:
  range: 1263.06GB -> 601.87GB
  range spread: 83.82% -> 36.66%
  std. deviation: 252.66GB -> 157.11GB
  min-max: 1506.80GB, 2769.86GB -> 1641.63GB, 2243.50GB
  -
  Broker 2354: 2131.32 -> 2131.32 (+0.00GB, 0.00%) 
  Broker 2356: 1877.01 -> 1877.01 (+0.00GB, 0.00%) 
  Broker 2357: 2044.16 -> 2044.16 (+0.00GB, 0.00%) 
  Broker 2359: 2042.12 -> 2042.12 (+0.00GB, 0.00%) 
  Broker 2360: 1506.80 -> 2033.16 (+526.36GB, 34.93%) 
<truncated>
```

Closes #276 