### PR TITLE
[testing] jamie/phased reassignments

### DIFF
--- a/cmd/topicmappr/README.md
+++ b/cmd/topicmappr/README.md
@@ -74,7 +74,7 @@ Usage:
   topicmappr rebuild [flags]
 
 Flags:
-      --brokers string                Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)
+      --brokers string                Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)
       --force-rebuild                 Forces a complete map rebuild
   -h, --help                          help for rebuild
       --map-string string             Rebuild a partition map provided as a string literal
@@ -85,6 +85,7 @@ Flags:
       --out-file string               If defined, write a combined map of all topics to a file
       --out-path string               Path to write output map files to
       --partition-size-factor float   Factor by which to multiply partition sizes when using storage placement (default 1)
+      --phased-reassignment           Create two-phase output maps
       --placement string              Partition placement strategy: [count, storage] (default "count")
       --replication int               Normalize the topic replication factor across all replica sets (0 results in a no-op)
       --skip-no-ops                   Skip no-op partition assigments
@@ -108,7 +109,7 @@ Usage:
   topicmappr rebalance [flags]
 
 Flags:
-      --brokers string                 Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)
+      --brokers string                 Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)
   -h, --help                           help for rebalance
       --locality-scoped                Disallow a relocation to traverse rack.id values among brokers
       --metrics-age int                Kafka metrics age tolerance (in minutes) (default 60)

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -239,7 +239,7 @@ func writeMaps(cmd *cobra.Command, pm *kafkazk.PartitionMap, phasedPM *kafkazk.P
 
 	outputMaps := []*kafkazk.PartitionMap{phasedPM, pm}
 
-	// For
+	// For each map type, create per-topic maps.
 	for i, m := range outputMaps {
 		// We may not have a phasedPM.
 		if m == nil {

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -38,7 +38,7 @@ func init() {
 	rebalanceCmd.Flags().String("topics", "", "Rebuild topics (comma delim. list) by lookup in ZooKeeper")
 	rebalanceCmd.Flags().String("out-path", "", "Path to write output map files to")
 	rebalanceCmd.Flags().String("out-file", "", "If defined, write a combined map of all topics to a file")
-	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)")
+	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)")
 	rebalanceCmd.Flags().Float64("storage-threshold", 0.20, "Percent below the harmonic mean storage free to target for partition offload (0 targets a brokers)")
 	rebalanceCmd.Flags().Float64("storage-threshold-gb", 0.00, "Storage free in gigabytes to target for partition offload (those below the specified value); 0 [default] defers target selection to --storage-threshold")
 	rebalanceCmd.Flags().Float64("tolerance", 0.0, "Percent distance from the mean storage free to limit storage scheduling (0 performs automatic tolerance selection)")

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -231,5 +231,5 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	partitionMapIn, partitionMapOut = skipReassignmentNoOps(partitionMapIn, partitionMapOut)
 
 	// Write maps.
-	writeMaps(cmd, partitionMapOut)
+	writeMaps(cmd, partitionMapOut, nil)
 }

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -36,12 +36,12 @@ func init() {
 	rebuildCmd.Flags().Int("min-rack-ids", 0, "Minimum number of required of unique rack IDs per replica set (0 requires that all are unique)")
 	rebuildCmd.Flags().String("optimize", "distribution", "Optimization priority for the storage placement strategy: [distribution, storage]")
 	rebuildCmd.Flags().Float64("partition-size-factor", 1.0, "Factor by which to multiply partition sizes when using storage placement")
-	rebuildCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' automatically expands to all currently mapped brokers)")
+	rebuildCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)")
 	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")
 	rebuildCmd.Flags().Bool("optimize-leadership", false, "Rebalance all broker leader/follower ratios")
-	rebuildCmd.Flags().Bool("phased-reassignment", false, "Created two-phase output maps")
+	rebuildCmd.Flags().Bool("phased-reassignment", false, "Create two-phase output maps")
 
 	// Required.
 	rebuildCmd.MarkFlagRequired("brokers")

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -246,7 +246,7 @@ func buildMap(cmd *cobra.Command, pm *kafkazk.PartitionMap, pmm kafkazk.Partitio
 // phasedReassignment takes the input map (the current ISR states) and the
 // output map (the results of the topicmappr input parameters / computation)
 // and prepends the current leaders as the leaders of the output map.
-func phasedReassignment(pm1, pm2 *kafkazk.PartitionMap) []*kafkazk.PartitionMap {
+func phasedReassignment(pm1, pm2 *kafkazk.PartitionMap) *kafkazk.PartitionMap {
 	// Get topics from output partition map.
 	topics := pm2.Topics()
 
@@ -266,5 +266,5 @@ func phasedReassignment(pm1, pm2 *kafkazk.PartitionMap) []*kafkazk.PartitionMap 
 		}
 	}
 
-	return []*kafkazk.PartitionMap{phase1pm}
+	return phase1pm
 }

--- a/cmd/topicmappr/commands/rebuild_steps_test.go
+++ b/cmd/topicmappr/commands/rebuild_steps_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"testing"
+
+	"github.com/DataDog/kafka-kit/kafkazk"
 )
 
 func TestNotInReplicaSet(t *testing.T) {
@@ -13,5 +15,41 @@ func TestNotInReplicaSet(t *testing.T) {
 
 	if notInReplicaSet(1010, rs) != true {
 		t.Errorf("Expected true assertion for ID 1010 in replica set")
+	}
+}
+
+func TestPhasedReassignment(t *testing.T) {
+	zk := kafkazk.Mock{}
+	pm1, _ := zk.GetPartitionMap("test_topic")
+	pm2 := pm1.Copy()
+
+	phased := phasedReassignment(pm1, pm2)
+
+	// These maps should be equal; phasedReassignment will
+	// be a no-op since all of the pm2 leaders == the pm1 leaders.
+	if eq, _ := pm2.Equal(phased); !eq {
+		t.Errorf("Unexpected PartitionMap inequality")
+	}
+
+	// Strip the pm2 leaders.
+	for i := range pm2.Partitions {
+		pm2.Partitions[i].Replicas = pm2.Partitions[i].Replicas[1:]
+	}
+
+	// We should expect the pm1 leaders now.
+	phased = phasedReassignment(pm1, pm2)
+
+	// Check for a non no-op.
+	if eq, _ := pm2.Equal(phased); eq {
+		t.Errorf("Unexpected PartitionMap equality")
+	}
+
+	// Validate each partition leader.
+	for i := range phased.Partitions {
+		phasedOutputLeader := phased.Partitions[i].Replicas[0]
+		originalLeader := pm1.Partitions[i].Replicas[0]
+		if phasedOutputLeader != originalLeader {
+			t.Errorf("Expected leader ID %d in phased output map, got %d", phasedOutputLeader, originalLeader)
+		}
 	}
 }

--- a/cmd/topicmappr/commands/rebuild_steps_test.go
+++ b/cmd/topicmappr/commands/rebuild_steps_test.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestNotInReplicaSet(t *testing.T) {
+	rs := []int{1001, 1002, 1003}
+
+	if notInReplicaSet(1001, rs) != false {
+		t.Errorf("Expected ID 1001 in replica set")
+	}
+
+	if notInReplicaSet(1010, rs) != true {
+		t.Errorf("Expected true assertion for ID 1010 in replica set")
+	}
+}

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -715,9 +715,9 @@ func (pm *PartitionMap) Copy() *PartitionMap {
 	return cpy
 }
 
-// Equal checks the equality betwee two partition maps. Equality requires
+// Equal checks the ity betwee two partition maps. Equality requires
 // that the total order is exactly the same.
-func (pm *PartitionMap) equal(pm2 *PartitionMap) (bool, error) {
+func (pm *PartitionMap) Equal(pm2 *PartitionMap) (bool, error) {
 	// Crude checks.
 	switch {
 	case len(pm.Partitions) != len(pm2.Partitions):

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -665,6 +665,25 @@ func (pm *PartitionMap) SetReplication(r int) {
 	}
 }
 
+// Topics returns a []string of topic names held in the PartitionMap.
+func (pm *PartitionMap) Topics() []string {
+	// Set.
+	m := map[string]struct{}{}
+	// List.
+	ts := []string{}
+
+	for _, p := range pm.Partitions {
+		if _, seen := m[p.Topic]; !seen {
+			ts = append(ts, p.Topic)
+			m[p.Topic] = struct{}{}
+		}
+	}
+
+	sort.Strings(ts)
+
+	return ts
+}
+
 // ReplicaSets takes a topic name and returns a ReplicaSets.
 func (pm *PartitionMap) ReplicaSets(t string) ReplicaSets {
 	rs := ReplicaSets{}

--- a/kafkazk/partitions.go
+++ b/kafkazk/partitions.go
@@ -154,6 +154,11 @@ func NewPartitionMetaMap() PartitionMetaMap {
 	return map[string]map[int]*PartitionMeta{}
 }
 
+// ReplicaSets is a mapping of partition number to Partition.Replicas.
+// Take note that there is no topic identifier and that partition
+// numbers from two different topics can overwrite one another.
+type ReplicaSets map[int][]int
+
 // Size takes a Partition and returns the size. An error is returned if
 // the partition isn't in the PartitionMetaMap.
 func (pmm PartitionMetaMap) Size(p Partition) (float64, error) {
@@ -658,6 +663,19 @@ func (pm *PartitionMap) SetReplication(r int) {
 			pm.Partitions[n].Replicas = append(p.Replicas, r...)
 		}
 	}
+}
+
+// ReplicaSets takes a topic name and returns a ReplicaSets.
+func (pm *PartitionMap) ReplicaSets(t string) ReplicaSets {
+	rs := ReplicaSets{}
+
+	for _, p := range pm.Partitions {
+		if p.Topic == t {
+			rs[p.Partition] = p.Replicas
+		}
+	}
+
+	return rs
 }
 
 // Copy returns a copy of a *PartitionMap.

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -154,13 +154,13 @@ func TestEqual(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
 	pm2, _ := PartitionMapFromString(testGetMapString("test_topic"))
 
-	if same, _ := pm.equal(pm2); !same {
+	if same, _ := pm.Equal(pm2); !same {
 		t.Error("Unexpected inequality")
 	}
 
 	// Test truncated partition list.
 	pm.Partitions = pm.Partitions[:2]
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 
@@ -168,7 +168,7 @@ func TestEqual(t *testing.T) {
 
 	// Test version.
 	pm.Version = 2
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 	pm.Version = 1
@@ -177,13 +177,13 @@ func TestEqual(t *testing.T) {
 
 	// Test topic order.
 	pm.Partitions[1].Topic = "test_topic2"
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 
 	// Test partition order.
 	pm.Partitions[0], pm.Partitions[1] = pm.Partitions[1], pm.Partitions[0]
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 
@@ -191,7 +191,7 @@ func TestEqual(t *testing.T) {
 
 	// Test replica list.
 	pm.Partitions[0].Replicas = pm.Partitions[0].Replicas[:1]
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 
@@ -199,7 +199,7 @@ func TestEqual(t *testing.T) {
 
 	// Test replicas.
 	pm.Partitions[0].Replicas[0] = 1337
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 }
@@ -246,14 +246,14 @@ func TestPartitionMapCopy(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
 	pm2 := pm.Copy()
 
-	if same, _ := pm.equal(pm2); !same {
+	if same, _ := pm.Equal(pm2); !same {
 		t.Error("Unexpected inequality")
 	}
 
 	// After modifying the partitions list,
 	// we expect inequality.
 	pm.Partitions = pm.Partitions[:2]
-	if same, _ := pm.equal(pm2); same {
+	if same, _ := pm.Equal(pm2); same {
 		t.Error("Unexpected equality")
 	}
 }
@@ -264,7 +264,7 @@ func TestPartitionMapFromString(t *testing.T) {
 	pm2, _ := zk.GetPartitionMap("test_topic")
 
 	// We expect equality here.
-	if same, _ := pm.equal(pm2); !same {
+	if same, _ := pm.Equal(pm2); !same {
 		t.Error("Unexpected inequality")
 	}
 }
@@ -300,7 +300,7 @@ func TestPartitionMapFromZK(t *testing.T) {
 	}
 
 	// Compare.
-	if same, err := pm.equal(pm2); !same {
+	if same, err := pm.Equal(pm2); !same {
 		t.Errorf("Unexpected inequality: %s", err)
 	}
 
@@ -419,7 +419,7 @@ func TestRebuildByCount(t *testing.T) {
 	// This rebuild should be a no-op since
 	// all brokers already in the map were provided,
 	// none marked as replace.
-	if same, _ := pm.equal(out); !same {
+	if same, _ := pm.Equal(out); !same {
 		t.Error("Expected no-op, partition map changed")
 	}
 
@@ -437,7 +437,7 @@ func TestRebuildByCount(t *testing.T) {
 	expected.Partitions[2].Replicas = []int{1003, 1002, 1001}
 	expected.Partitions[3].Replicas = []int{1001, 1003, 1002}
 
-	if same, err := out.equal(expected); !same {
+	if same, err := out.Equal(expected); !same {
 		t.Errorf("Unexpected inequality after broker replacement: %s", err)
 	}
 
@@ -448,7 +448,7 @@ func TestRebuildByCount(t *testing.T) {
 
 	out, _ = pm.Rebuild(rebuildParams)
 
-	if same, err := out.equal(expected); !same {
+	if same, err := out.Equal(expected); !same {
 		t.Errorf("Unexpected inequality after replication factor change -> rebuild: %s", err)
 	}
 
@@ -469,7 +469,7 @@ func TestRebuildByCount(t *testing.T) {
 	expected.Partitions[5].Replicas = []int{1002, 1004}
 	expected.Partitions[6].Replicas = []int{1003, 1001}
 
-	same, err := out.equal(expected)
+	same, err := out.Equal(expected)
 	if !same {
 		t.Errorf("Unexpected inequality after force rebuild: %s", err)
 	}
@@ -525,7 +525,7 @@ func TestRebuildByCountSA(t *testing.T) {
 	expected.Partitions[4].Replicas = []int{1001, 1003}
 	expected.Partitions[5].Replicas = []int{1010, 1001}
 
-	if same, err := out.equal(expected); !same {
+	if same, err := out.Equal(expected); !same {
 		t.Errorf("Unexpected inequality after rebuild: %s", err)
 	}
 }
@@ -580,7 +580,7 @@ func TestRebuildByStorageDistribution(t *testing.T) {
 	expected.Partitions[4].Replicas = []int{1003, 1004}
 	expected.Partitions[5].Replicas = []int{1001, 1002}
 
-	same, err := out.equal(expected)
+	same, err := out.Equal(expected)
 	if !same {
 		t.Errorf("Unexpected inequality after rebuild: %s", err)
 	}
@@ -636,7 +636,7 @@ func TestRebuildByStorageStorage(t *testing.T) {
 	expected.Partitions[4].Replicas = []int{1003, 1004}
 	expected.Partitions[5].Replicas = []int{1001, 1002}
 
-	same, err := out.equal(expected)
+	same, err := out.Equal(expected)
 	if !same {
 		t.Errorf("Unexpected inequality after rebuild: %s", err)
 	}
@@ -689,7 +689,7 @@ func TestShuffle(t *testing.T) {
 
 	pm.shuffle((func(_ Partition) bool { return true }))
 
-	if same, _ := pm.equal(expected); !same {
+	if same, _ := pm.Equal(expected); !same {
 		t.Errorf("Unexpected shuffle results")
 	}
 }

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -94,6 +94,16 @@ func testGetMapString4(n string) string {
     {"topic":"%s","partition":5,"replicas":[1002,1001]}]}`, n, n, n, n, n, n)
 }
 
+func testGetMapString5(n string) string {
+	return fmt.Sprintf(`{"version":1,"partitions":[
+    {"topic":"%s1","partition":0,"replicas":[1004,1003]},
+    {"topic":"%s1","partition":1,"replicas":[1003,1004]},
+    {"topic":"%s1","partition":2,"replicas":[1001,1002]},
+		{"topic":"%s2","partition":3,"replicas":[1003,1002]},
+		{"topic":"%s2","partition":4,"replicas":[1001,1003]},
+    {"topic":"%s2","partition":5,"replicas":[1002,1001]}]}`, n, n, n, n, n, n)
+}
+
 func TestSize(t *testing.T) {
 	z := &Mock{}
 
@@ -194,9 +204,21 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestPartitionMapTopics(t *testing.T) {
+	pm, _ := PartitionMapFromString(testGetMapString5("test_topic"))
+	ts := pm.Topics()
+
+	expected := []string{"test_topic1", "test_topic2"}
+
+	for i, n := range ts {
+		if n != expected[i] {
+			t.Errorf("Expected topic '%s', got '%s'", expected[i], n)
+		}
+	}
+}
+
 func TestPartitionMapReplicaSets(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
-
 	rs := pm.ReplicaSets("test_topic")
 
 	expected := ReplicaSets{

--- a/kafkazk/partitions_test.go
+++ b/kafkazk/partitions_test.go
@@ -194,6 +194,32 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestPartitionMapReplicaSets(t *testing.T) {
+	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
+
+	rs := pm.ReplicaSets("test_topic")
+
+	expected := ReplicaSets{
+		0: []int{1001, 1002},
+		1: []int{1002, 1001},
+		2: []int{1003, 1004, 1001},
+		3: []int{1004, 1003, 1002},
+	}
+
+	if len(rs) != len(expected) {
+		t.Error("Unexpected ReplicaSets len")
+	}
+
+	for i, expectedSet := range expected {
+		for j := range expectedSet {
+			if expectedSet[j] != rs[i][j] {
+				fmt.Printf("%v %v\n", expectedSet[j], rs[i][j])
+				t.Errorf("ReplicaSet mismatch")
+			}
+		}
+	}
+}
+
 func TestPartitionMapCopy(t *testing.T) {
 	pm, _ := PartitionMapFromString(testGetMapString("test_topic"))
 	pm2 := pm.Copy()

--- a/kafkazk/zookeeper_test.go
+++ b/kafkazk/zookeeper_test.go
@@ -819,7 +819,7 @@ func TestGetPartitionMap(t *testing.T) {
 		},
 	}
 
-	if matches, err := pm.equal(expected); !matches {
+	if matches, err := pm.Equal(expected); !matches {
 		t.Errorf("Unexpected PartitionMap inequality: %s", err)
 	}
 }


### PR DESCRIPTION
This PR introduces phased reassignments (closes #279). Currently testing / in cleanup.

```
% topicmappr rebuild \
--map-string '{"version":1,"partitions":[{"topic":"test_topic","partition":0,"replicas":[1001,1002]},{"topic":"test_topic","partition":1,"replicas":[1002,1003]},{"topic":"test_topic","partition":2,"replicas":[1003,1001]},{"topic":"test_topic","partition":3,"replicas":[1001,1003]}]}' \
--brokers=1004,1005,1006 --phased-reassignment                    

Topics:
  test_topic

Broker change summary:
  Broker 1001 marked for removal
  Broker 1002 marked for removal
  Broker 1003 marked for removal
  New broker 1005
  New broker 1006
  New broker 1004
  -
  Replacing 3, added 3, missing 0, total count changed by 0

Action:
  Rebuild topic with 3 broker(s) marked for replacement

Partition map changes:
  test_topic p0: [1001 1002] -> [1004 1005] replaced broker
  test_topic p1: [1002 1003] -> [1005 1006] replaced broker
  test_topic p2: [1003 1001] -> [1006 1004] replaced broker
  test_topic p3: [1001 1003] -> [1004 1006] replaced broker

Broker distribution:
  degree [min/max/avg]: 2/2/2.00 -> 2/2/2.00
  -
  Broker 1004 - leader: 2, follower: 1, total: 3
  Broker 1005 - leader: 1, follower: 1, total: 2
  Broker 1006 - leader: 1, follower: 2, total: 3

WARN:
  [none]

New partition maps:
  test_topic-phase2.json
  test_topic-phase1.json
```

Phase 1:
```
% jq . test_topic-phase1.json 
{
  "version": 1,
  "partitions": [
    {
      "topic": "test_topic",
      "partition": 0,
      "replicas": [
        1001,
        1004,
        1005
      ]
    },
    {
      "topic": "test_topic",
      "partition": 1,
      "replicas": [
        1002,
        1005,
        1006
      ]
    },
    {
      "topic": "test_topic",
      "partition": 2,
      "replicas": [
        1003,
        1006,
        1004
      ]
    },
    {
      "topic": "test_topic",
      "partition": 3,
      "replicas": [
        1001,
        1004,
        1006
      ]
    }
  ]
}
```

Phase 2:
```
% jq . test_topic-phase2.json
{
  "version": 1,
  "partitions": [
    {
      "topic": "test_topic",
      "partition": 0,
      "replicas": [
        1004,
        1005
      ]
    },
    {
      "topic": "test_topic",
      "partition": 1,
      "replicas": [
        1005,
        1006
      ]
    },
    {
      "topic": "test_topic",
      "partition": 2,
      "replicas": [
        1006,
        1004
      ]
    },
    {
      "topic": "test_topic",
      "partition": 3,
      "replicas": [
        1004,
        1006
      ]
    }
  ]
}
```