### PR TITLE
handles nil request body field

### DIFF
--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -19,6 +19,8 @@ var (
 	ErrTopicNotExist = errors.New("topic does not exist")
 	// ErrTopicNameEmpty error.
 	ErrTopicNameEmpty = errors.New("topic Name field must be specified")
+	// ErrTopicFieldMissing error.
+	ErrTopicFieldMissing = errors.New("topic field missing in request body")
 	// ErrTopicAlreadyExists error.
 	ErrTopicAlreadyExists = errors.New("topic already exists")
 	// ErrInsufficientBrokers error.
@@ -83,6 +85,14 @@ func (s *Server) CreateTopic(ctx context.Context, req *pb.CreateTopicRequest) (*
 	ctx, err := s.ValidateRequest(ctx, req, writeRequest)
 	if err != nil {
 		return empty, err
+	}
+
+	if req.Topic == nil {
+		return nil, ErrTopicFieldMissing
+	}
+
+	if req.Topic.Name == "" {
+		return nil, ErrTopicNameEmpty
 	}
 
 	reqParams := &pb.TopicRequest{Name: req.Topic.Name}
@@ -308,7 +318,7 @@ func (s *Server) DeleteTopicTags(ctx context.Context, req *pb.TopicRequest) (*pb
 	return &pb.TagResponse{Message: "success"}, nil
 }
 
-// fetchBrokerSet fetches metadata for all topics.
+// fetchTopicSet fetches metadata for all topics.
 func (s *Server) fetchTopicSet(req *pb.TopicRequest) (TopicSet, error) {
 	topicRegex := []*regexp.Regexp{}
 

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -267,7 +267,7 @@ func (s *Server) DialZK(ctx context.Context, wg *sync.WaitGroup, c *kafkazk.Conf
 // context and error are returned.
 func (s *Server) ValidateRequest(ctx context.Context, req interface{}, kind int) (context.Context, error) {
 	// Check if this context has already been seen. If so, it's likely that
-	// one gRPC call is interally calling another and visiting ValidateRequest
+	// one gRPC call is internally calling another and visiting ValidateRequest
 	// multiple times. In this case, we don't need to do further rate limiting,
 	// logging, and other steps.
 	if _, seen := ctx.Value("reqID").(uint64); seen {


### PR DESCRIPTION
# Changes

This PR fixes a segfault in the Registry service. Closes #283.

# Notes
In the CreateTopic RPC, the request body `topic` field is a proto message type and can be nil. The Registry service currently segfaults while attempting to access a subfield when provided an empty request:

```
$ curl -XPOST --data "{}" localhost:8080/v1/topics/create
```

```
2020/01/21 21:33:49 [request 1] requestor:127.0.0.1:60426 type:http method:/registry.Registry/CreateTopic params:none
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x8dc409]

goroutine 73 [running]:
github.com/DataDog/kafka-kit/registry/server.(*Server).CreateTopic(0xc00011c300, 0xb5d040, 0xc00002d2f0, 0xc0000912c0, 0xc00011c300, 0xc00002d230, 0xc0004d2a80)
	/go/src/github.com/DataDog/kafka-kit/registry/server/api_topics.go:88 +0xe9
github.com/DataDog/kafka-kit/registry/protos._Registry_CreateTopic_Handler(0xa59b60, 0xc00011c300, 0xb5d040, 0xc00002d230, 0xc0002ec840, 0x0, 0xb5d040, 0xc00002d230, 0x0, 0x0)
	/go/src/github.com/DataDog/kafka-kit/registry/protos/registry.pb.go:972 +0x217
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00032b500, 0xb626a0, 0xc000316180, 0xc000146600, 0xc00002c3c0, 0x1102dc0, 0x0, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:1007 +0x460
google.golang.org/grpc.(*Server).handleStream(0xc00032b500, 0xb626a0, 0xc000316180, 0xc000146600, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:1287 +0xd97
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0004f2030, 0xc00032b500, 0xb626a0, 0xc000316180, 0xc000146600)
	/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:722 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:720 +0xa1
```