### PR TITLE
[topicmapper] Handle missing rack info

### DIFF
--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -171,6 +171,13 @@ func rebuild(cmd *cobra.Command, _ []string) {
 		errs = append(errs, fmt.Errorf("%d provided brokers not found in ZooKeeper", bs.Missing))
 	}
 
+	// Count missing rack info as warning
+	if bs.RackMissing > 0 {
+		errs = append(
+			errs, fmt.Errorf("%d provided broker(s) do(es) not have a rack.id defined", bs.RackMissing),
+		)
+	}
+
 	// Generate phased map if enabled.
 	var phasedMap *kafkazk.PartitionMap
 	if phased, _ := cmd.Flags().GetBool("phased-reassignment"); phased {

--- a/kafkazk/brokers_test.go
+++ b/kafkazk/brokers_test.go
@@ -134,10 +134,10 @@ func TestUpdate(t *testing.T) {
 
 	// 1006 doesn't exist in the meta map.
 	// This should also add to the missing.
-	stat, _ := bm.Update([]int{1002, 1003, 1005, 1006}, bmm)
+	stat, _ := bm.Update([]int{1002, 1003, 1005, 1006, 1007}, bmm)
 
-	if stat.New != 1 {
-		t.Errorf("Expected New count of 1, got %d", stat.New)
+	if stat.New != 2 {
+		t.Errorf("Expected New count of 2, got %d", stat.New)
 	}
 	if stat.Missing != 2 {
 		t.Errorf("Expected Missing count of 2, got %d", stat.Missing)
@@ -148,9 +148,14 @@ func TestUpdate(t *testing.T) {
 	if stat.Replace != 2 {
 		t.Errorf("Expected Replace count of 2, got %d", stat.Replace)
 	}
+	// 1003 does not have rack defined
+	// 1007 (new broker) also does not have rack defined
+	if stat.RackMissing != 2 {
+		t.Errorf("Expected Rack missing count of 2, got %d", stat.RackMissing)
+	}
 
 	// Ensure all broker IDs are in the map.
-	for _, id := range []int{StubBrokerID, 1001, 1002, 1003, 1004, 1005} {
+	for _, id := range []int{StubBrokerID, 1001, 1002, 1003, 1004, 1005, 1007} {
 		if _, ok := bm[id]; !ok {
 			t.Errorf("Expected presence of ID %d", id)
 		}
@@ -193,6 +198,13 @@ func TestUpdate(t *testing.T) {
 
 	if _, exists := bm[1006]; exists {
 		t.Error("ID 1006 unexpectedly exists in BrokerMap")
+	}
+
+	if bm[1007].Missing || bm[1007].Replace {
+		t.Error("Unexpected fields set for ID 1007")
+	}
+	if !bm[1007].New {
+		t.Error("Expected ID 1007 New == true")
 	}
 }
 
@@ -414,7 +426,7 @@ func newMockBrokerMap() BrokerMap {
 		StubBrokerID: &Broker{ID: StubBrokerID, Replace: true},
 		1001:         &Broker{ID: 1001, Locality: "a", Used: 3, Replace: false, StorageFree: 100.00},
 		1002:         &Broker{ID: 1002, Locality: "b", Used: 3, Replace: false, StorageFree: 200.00},
-		1003:         &Broker{ID: 1003, Locality: "c", Used: 2, Replace: false, StorageFree: 300.00},
+		1003:         &Broker{ID: 1003, Locality: "", Used: 2, Replace: false, StorageFree: 300.00},
 		1004:         &Broker{ID: 1004, Locality: "a", Used: 2, Replace: false, StorageFree: 400.00},
 	}
 }

--- a/kafkazk/zookeeper_mocks.go
+++ b/kafkazk/zookeeper_mocks.go
@@ -160,9 +160,10 @@ func (zk *Mock) GetAllBrokerMeta(withMetrics bool) (BrokerMetaMap, []error) {
 	b := BrokerMetaMap{
 		1001: &BrokerMeta{Rack: "a"},
 		1002: &BrokerMeta{Rack: "b"},
-		1003: &BrokerMeta{Rack: "c"},
+		1003: &BrokerMeta{Rack: ""},
 		1004: &BrokerMeta{Rack: "a"},
 		1005: &BrokerMeta{Rack: "b"},
+		1007: &BrokerMeta{Rack: ""},
 	}
 
 	if withMetrics {
@@ -184,6 +185,7 @@ func (zk *Mock) GetBrokerMetrics() (BrokerMetricsMap, error) {
 		1003: &BrokerMetrics{StorageFree: 6000.00},
 		1004: &BrokerMetrics{StorageFree: 8000.00},
 		1005: &BrokerMetrics{StorageFree: 10000.00},
+		1007: &BrokerMetrics{StorageFree: 12000.00},
 	}
 
 	return bm, nil

--- a/registry/server/api_brokers_test.go
+++ b/registry/server/api_brokers_test.go
@@ -17,7 +17,7 @@ func TestGetBrokers(t *testing.T) {
 	}
 
 	expected := map[int]idList{
-		0: idList{1001, 1002, 1003, 1004, 1005},
+		0: idList{1001, 1002, 1003, 1004, 1005, 1007},
 		1: idList{1002},
 		2: idList{1001, 1004},
 	}
@@ -50,7 +50,7 @@ func TestListBrokers(t *testing.T) {
 	}
 
 	expected := map[int]idList{
-		0: idList{1001, 1002, 1003, 1004, 1005},
+		0: idList{1001, 1002, 1003, 1004, 1005, 1007},
 		1: idList{1002},
 		2: idList{1001, 1004},
 	}


### PR DESCRIPTION
This PR adds the functionality in topicmapper to warn whenever a broker with missing rack.id is used as part of the brokers. Closes #50.

Why? If rack data is missing, unintended constraint passes may occur (e.g. a leader/follower in the same AZ).

# Testing
```
$ docker-compose run --rm --name registry_test registry go test -v ./...
=== RUN   TestChanges
--- PASS: TestChanges (0.00s)
=== RUN   TestSortBrokerListByCount
--- PASS: TestSortBrokerListByCount (0.00s)
=== RUN   TestSortBrokerListByStorage
--- PASS: TestSortBrokerListByStorage (0.00s)
=== RUN   TestSortBrokerListByID
--- PASS: TestSortBrokerListByID (0.00s)
=== RUN   TestSortPseudoShuffle
--- PASS: TestSortPseudoShuffle (0.00s)
=== RUN   TestUpdate
--- PASS: TestUpdate (0.00s)
=== RUN   TestUpdateIncludeExisting
--- PASS: TestUpdateIncludeExisting (0.00s)
=== RUN   TestSubStorageAll
--- PASS: TestSubStorageAll (0.00s)
=== RUN   TestSubStorageReplacements
--- PASS: TestSubStorageReplacements (0.00s)
=== RUN   TestMapFilter
--- PASS: TestMapFilter (0.00s)
=== RUN   TestListFilter
--- PASS: TestListFilter (0.00s)
=== RUN   TestBrokerMapFromPartitionMap
--- PASS: TestBrokerMapFromPartitionMap (0.00s)
=== RUN   TestBrokerMapCopy
--- PASS: TestBrokerMapCopy (0.00s)
=== RUN   TestBrokerCopy
--- PASS: TestBrokerCopy (0.00s)
=== RUN   TestSelectBrokerByCount
--- PASS: TestSelectBrokerByCount (0.00s)
=== RUN   TestSelectBrokerByStorage
--- PASS: TestSelectBrokerByStorage (0.00s)
=== RUN   TestBestCandidateByCount
--- PASS: TestBestCandidateByCount (0.00s)
=== RUN   TestBestCandidateByStorage
--- PASS: TestBestCandidateByStorage (0.00s)
=== RUN   TestConstraintsAdd
--- PASS: TestConstraintsAdd (0.00s)
=== RUN   TestConstraintsPasses
--- PASS: TestConstraintsPasses (0.00s)
=== RUN   TestConstraintsPassesWithParams
--- PASS: TestConstraintsPassesWithParams (0.00s)
=== RUN   TestMergeConstraints
--- PASS: TestMergeConstraints (0.00s)
=== RUN   TestMergeConstraintsX
--- PASS: TestMergeConstraintsX (0.00s)
=== RUN   TestMappings
--- PASS: TestMappings (0.00s)
=== RUN   TestLargestPartitions
--- PASS: TestLargestPartitions (0.00s)
=== RUN   TestRemove
--- PASS: TestRemove (0.00s)
=== RUN   TestNewPartitionMap
--- PASS: TestNewPartitionMap (0.00s)
=== RUN   TestPartitionEquality
--- PASS: TestPartitionEquality (0.00s)
=== RUN   TestSize
--- PASS: TestSize (0.00s)
=== RUN   TestSortBySize
--- PASS: TestSortBySize (0.00s)
=== RUN   TestEqual
--- PASS: TestEqual (0.00s)
=== RUN   TestPartitionMapTopics
--- PASS: TestPartitionMapTopics (0.00s)
=== RUN   TestPartitionMapReplicaSets
--- PASS: TestPartitionMapReplicaSets (0.00s)
=== RUN   TestPartitionMapCopy
--- PASS: TestPartitionMapCopy (0.00s)
=== RUN   TestPartitionMapFromString
--- PASS: TestPartitionMapFromString (0.00s)
=== RUN   TestPartitionMapFromZK
--- PASS: TestPartitionMapFromZK (0.00s)
=== RUN   TestSetReplication
--- PASS: TestSetReplication (0.00s)
=== RUN   TestStrip
--- PASS: TestStrip (0.00s)
=== RUN   TestUseStats
--- PASS: TestUseStats (0.00s)
=== RUN   TestRebuildByCount
--- PASS: TestRebuildByCount (0.00s)
=== RUN   TestRebuildByCountSA
--- PASS: TestRebuildByCountSA (0.00s)
=== RUN   TestRebuildByStorageDistribution
--- PASS: TestRebuildByStorageDistribution (0.00s)
=== RUN   TestRebuildByStorageStorage
--- PASS: TestRebuildByStorageStorage (0.00s)
=== RUN   TestLocalitiesAvailable
--- PASS: TestLocalitiesAvailable (0.00s)
=== RUN   TestShuffle
--- PASS: TestShuffle (0.00s)
=== RUN   TestDegreeDistribution
--- PASS: TestDegreeDistribution (0.00s)
=== RUN   TestBrokerMapStorageDiff
--- PASS: TestBrokerMapStorageDiff (0.00s)
=== RUN   TestBrokerMapStorageRangeSpread
--- PASS: TestBrokerMapStorageRangeSpread (0.00s)
=== RUN   TestBrokerMapStorageRange
--- PASS: TestBrokerMapStorageRange (0.00s)
=== RUN   TestBrokerMapStorageStdDev
--- PASS: TestBrokerMapStorageStdDev (0.00s)
=== RUN   TestBrokerListSort
--- PASS: TestBrokerListSort (0.00s)
=== RUN   TestHMean
--- PASS: TestHMean (0.00s)
=== RUN   TestMean
--- PASS: TestMean (0.00s)
=== RUN   TestAboveMean
--- PASS: TestAboveMean (0.00s)
=== RUN   TestBelowMean
--- PASS: TestBelowMean (0.00s)
=== RUN   TestConstraintsMatch
--- PASS: TestConstraintsMatch (0.00s)
=== RUN   TestSubstitutionAffinities
--- PASS: TestSubstitutionAffinities (0.00s)
=== RUN   TestSubstitutionAffinitiesInferred
--- PASS: TestSubstitutionAffinitiesInferred (0.00s)
=== RUN   TestSetup
--- PASS: TestSetup (0.29s)
=== RUN   TestCreateSetGetDelete
--- PASS: TestCreateSetGetDelete (0.00s)
=== RUN   TestCreateSequential
--- PASS: TestCreateSequential (0.00s)
=== RUN   TestExists
--- PASS: TestExists (0.00s)
=== RUN   TestGetReassignments
--- PASS: TestGetReassignments (0.00s)
=== RUN   TestGetPendingDeletion
--- PASS: TestGetPendingDeletion (0.00s)
=== RUN   TestGetTopics
--- PASS: TestGetTopics (0.00s)
=== RUN   TestGetTopicConfig
--- PASS: TestGetTopicConfig (0.00s)
=== RUN   TestGetAllBrokerMeta
--- PASS: TestGetAllBrokerMeta (0.00s)
=== RUN   TestGetBrokerMetrics
--- PASS: TestGetBrokerMetrics (0.00s)
=== RUN   TestGetBrokerMetricsCompressed
--- PASS: TestGetBrokerMetricsCompressed (0.00s)
=== RUN   TestGetAllPartitionMeta
--- PASS: TestGetAllPartitionMeta (0.00s)
=== RUN   TestGetAllPartitionMetaCompressed
--- PASS: TestGetAllPartitionMetaCompressed (0.00s)
=== RUN   TestOldestMetaTs
--- PASS: TestOldestMetaTs (0.01s)
=== RUN   TestGetTopicState
--- PASS: TestGetTopicState (0.00s)
=== RUN   TestGetTopicStateISR
--- PASS: TestGetTopicStateISR (0.00s)
=== RUN   TestGetPartitionMap
--- PASS: TestGetPartitionMap (0.00s)
=== RUN   TestUpdateKafkaConfigBroker
--- PASS: TestUpdateKafkaConfigBroker (0.00s)
=== RUN   TestUpdateKafkaConfigTopic
--- PASS: TestUpdateKafkaConfigTopic (0.00s)
=== RUN   TestTearDown
--- PASS: TestTearDown (0.06s)
=== RUN   TestGetBrokers
--- PASS: TestGetBrokers (0.00s)
=== RUN   TestListBrokers
--- PASS: TestListBrokers (0.00s)
=== RUN   TestCustomTagBrokerFilter
--- PASS: TestCustomTagBrokerFilter (0.00s)
=== RUN   TestTagBroker
--- PASS: TestTagBroker (0.00s)
=== RUN   TestDeleteBrokerTags
--- PASS: TestDeleteBrokerTags (0.00s)
=== RUN   TestDeleteBrokerTagsFailures
--- PASS: TestDeleteBrokerTagsFailures (0.00s)
=== RUN   TestBrokerMappings
--- PASS: TestBrokerMappings (0.00s)
=== RUN   TestGetTopics
--- PASS: TestGetTopics (0.00s)
=== RUN   TestListTopics
--- PASS: TestListTopics (0.00s)
=== RUN   TestCustomTagTopicFilter
--- PASS: TestCustomTagTopicFilter (0.00s)
=== RUN   TestTagTopic
--- PASS: TestTagTopic (0.00s)
=== RUN   TestDeleteTopicTags
--- PASS: TestDeleteTopicTags (0.00s)
=== RUN   TestDeleteTopicTagsFailures
--- PASS: TestDeleteTopicTagsFailures (0.00s)
=== RUN   TestTopicMappings
--- PASS: TestTopicMappings (0.00s)
=== RUN   TestTagSetFromObject
--- PASS: TestTagSetFromObject (0.00s)
=== RUN   TestMatchAll
--- PASS: TestMatchAll (0.00s)
=== RUN   TestEqual
--- PASS: TestEqual (0.00s)
=== RUN   TestTags
--- PASS: TestTags (0.00s)
=== RUN   TestTagSet
--- PASS: TestTagSet (0.00s)
=== RUN   TestValid
--- PASS: TestValid (0.00s)
=== RUN   TestComplete
--- PASS: TestComplete (0.00s)
=== RUN   TestFilterTopics
--- PASS: TestFilterTopics (0.00s)
=== RUN   TestFilterBrokers
--- PASS: TestFilterBrokers (0.00s)
=== RUN   TestReservedFields
--- PASS: TestReservedFields (0.00s)
=== RUN   TestSetup
--- PASS: TestSetup (0.26s)
=== RUN   TestSetTags
--- PASS: TestSetTags (0.00s)
=== RUN   TestTagSetFailures
--- PASS: TestTagSetFailures (0.00s)
=== RUN   TestGetTags
--- PASS: TestGetTags (0.00s)
=== RUN   TestGetTagsFailures
--- PASS: TestGetTagsFailures (0.00s)
=== RUN   TestDeleteTags
--- PASS: TestDeleteTags (0.00s)
=== RUN   TestDeleteTagsFailures
--- PASS: TestDeleteTagsFailures (0.00s)
=== RUN   TestTearDown
--- PASS: TestTearDown (0.01s)
=== RUN   TestRequestThrottle
--- PASS: TestRequestThrottle (2.00s)
PASS
ok  	github.com/DataDog/kafka-kit/registry/server	2.282s
```
# Output example
```
Broker change summary:
  New broker 1004
  Broker 1001 does not have a rack.id defined
  Broker 1004 does not have a rack.id defined
  -
  Replacing 0, added 1, missing 0, total count changed by 1
...
WARN:
  2 provided broker(s) do(es) not have a rack.id defined
```