### PR TITLE
adds partition-size-factor to rebalance

### DIFF
--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -99,7 +99,7 @@ func printBrokerAssignmentStats(cmd *cobra.Command, pm1, pm2 *kafkazk.PartitionM
 
 	if cmd.Use == "rebalance" || cmd.Flag("placement").Value.String() == "storage" {
 		fmt.Println("\nStorage free change estimations:")
-		if psf != 1.0 && cmd.Use != "rebalance" {
+		if psf != 1.0 {
 			fmt.Printf("%sPartition size factor of %.2f applied\n", indent, psf)
 		}
 

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -44,6 +44,7 @@ func init() {
 	rebalanceCmd.Flags().Float64("tolerance", 0.0, "Percent distance from the mean storage free to limit storage scheduling (0 performs automatic tolerance selection)")
 	rebalanceCmd.Flags().Int("partition-limit", 30, "Limit the number of top partitions by size eligible for relocation per broker")
 	rebalanceCmd.Flags().Int("partition-size-threshold", 512, "Size in megabytes where partitions below this value will not be moved in a rebalance")
+	rebalanceCmd.Flags().Float64("partition-size-factor", 1.0, "Factor by which to multiply partition sizes")
 	rebalanceCmd.Flags().Bool("locality-scoped", false, "Disallow a relocation to traverse rack.id values among brokers")
 	rebalanceCmd.Flags().Bool("verbose", false, "Verbose output")
 	rebalanceCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
@@ -100,6 +101,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	partitionLimit, _ := cmd.Flags().GetInt("partition-limit")
 	partitionSizeThreshold, _ := cmd.Flags().GetInt("partition-size-threshold")
+	partitionSizeFactor, _ := cmd.Flags().GetFloat64("partition-size-factor")
 
 	otm := map[int]struct{}{}
 	for _, id := range offloadTargets {
@@ -139,6 +141,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 				plan:                   relocationPlan{},
 				topPartitionsLimit:     partitionLimit,
 				partitionSizeThreshold: partitionSizeThreshold,
+				partitionSizeFactor:    partitionSizeFactor,
 				offloadTargetsMap:      otm,
 				tolerance:              tol,
 			}

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -52,6 +52,7 @@ type planRelocationsForBrokerParams struct {
 	pass                   int
 	topPartitionsLimit     int
 	partitionSizeThreshold int
+	partitionSizeFactor    float64
 	offloadTargetsMap      map[int]struct{}
 	tolerance              float64
 }
@@ -236,6 +237,7 @@ func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBroke
 	sourceID := params.sourceID
 	topPartitionsLimit := params.topPartitionsLimit
 	partitionSizeThreshold := float64(params.partitionSizeThreshold * 1 << 20)
+	partitionSizeFactor := params.partitionSizeFactor
 	offloadTargetsMap := params.offloadTargetsMap
 	tolerance := params.tolerance
 
@@ -249,6 +251,7 @@ func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBroke
 	// Filter out partitions below the targeted size threshold.
 	for i, p := range topPartn {
 		pSize, _ := partitionMeta.Size(p)
+		pSize = pSize * partitionSizeFactor
 		if pSize < partitionSizeThreshold {
 			topPartn = topPartn[:i]
 			break
@@ -278,6 +281,7 @@ func planRelocationsForBroker(cmd *cobra.Command, params planRelocationsForBroke
 		brokerList.SortByStorage()
 
 		pSize, _ := partitionMeta.Size(partn)
+		pSize = pSize * partitionSizeFactor
 
 		// Find a destination broker.
 		var dest *kafkazk.Broker


### PR DESCRIPTION
Adds `--partition-size-factor` to the `Rebalance` command to calibrate the bin-packer for future partition sizes. Closes #287.