### PR TITLE
[registry][DRE-553] Add support for retrieving topic config metadata

### DIFF
--- a/kafkazk/zookeeper_mocks.go
+++ b/kafkazk/zookeeper_mocks.go
@@ -149,6 +149,7 @@ func (zk *Mock) GetTopicConfig(t string) (*TopicConfig, error) {
 	return &TopicConfig{
 		Version: 1,
 		Config: map[string]string{
+			"retention.ms":                            "172800000",
 			"leader.replication.throttled.replicas":   "0:1001,0:1002",
 			"follower.replication.throttled.replicas": "0:1003,0:1004",
 		},

--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"sort"
 
@@ -348,9 +347,13 @@ func (s *Server) fetchTopicSet(req *pb.TopicRequest) (TopicSet, error) {
 		st, _ := s.ZK.GetTopicState(t)
 		c, err := s.ZK.GetTopicConfig(t)
 		if err != nil {
-			log.Printf("Error getting config for '%s' topic", t)
-			c = &kafkazk.TopicConfig{}
-			c.Config = map[string]string{}
+			switch err.(type) {
+			case kafkazk.ErrNoNode:
+				c = &kafkazk.TopicConfig{}
+				c.Config = map[string]string{}
+			default:
+				return nil, err
+			}
 		}
 		matched[t] = &pb.Topic{
 			Name:       t,

--- a/registry/server/api_topics_test.go
+++ b/registry/server/api_topics_test.go
@@ -37,6 +37,16 @@ func TestGetTopics(t *testing.T) {
 		if !stringsEqual(expected[i], topics) {
 			t.Errorf("Expected Topic list %s, got %s", expected[i], topics)
 		}
+
+		for _, topic := range resp.Topics {
+			v, exist := topic.Configs["retention.ms"]
+			if !exist {
+				t.Error("Expected 'retention.ms' config key to exist")
+			}
+			if v != "172800000" {
+				t.Errorf("Expected config value '172800000', got '%s'", v)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Currently we support adding additional config in topic creation via the registry but these are not being shown in the get/list methods. This PR adds support for it.

Example retrieving topics config:
```
curl -s "localhost:8080/v1/topics" | jq .
{
  "topics": {
    "custom": {
      "name": "custom",
      "partitions": 2,
      "replication": 2,
      "configs": {
        "cleanup.policy": "compact",
        "retention.ms": "123456"
      }
    },
    "custom-2": {
      "name": "custom-2",
      "partitions": 3,
      "replication": 1,
      "configs": {
        "max.message.bytes": "123456",
        "retention.ms": "77777"
      }
    },
    "test1": {
      "name": "test1",
      "partitions": 1,
      "replication": 1
    }
  }
}
```

Specific topic retrieval:
```
$  curl -s "localhost:8080/v1/topics?name=custom-2" | jq .
{
  "topics": {
    "custom-2": {
      "name": "custom-2",
      "partitions": 3,
      "replication": 1,
      "configs": {
        "max.message.bytes": "123456",
        "retention.ms": "77777"
      }
    }
  }
}
```