### PR TITLE
[topicmappr] Ignore brokers not found in zk for missing rack.ids check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     environment:
       KAFKA_LISTENERS: PLAINTEXT://:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: "test1:1:3,test2:2:2"
+      KAFKA_BROKER_RACK: 1a
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   registry:

--- a/kafkazk/brokers.go
+++ b/kafkazk/brokers.go
@@ -346,9 +346,12 @@ func (b BrokerMap) Update(bl []int, bm BrokerMetaMap) (*BrokerStatus, <-chan str
 			if broker.ID == StubBrokerID {
 				continue
 			}
-			if broker.Locality == "" {
-				bs.RackMissing++
-				msgs <- fmt.Sprintf("Broker %d does not have a rack.id defined", broker.ID)
+			// ignore missing brokers not found in zk
+			if !b[broker.ID].Missing {
+				if broker.Locality == "" {
+					bs.RackMissing++
+					msgs <- fmt.Sprintf("Broker %d does not have a rack.id defined", broker.ID)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the misleading warning of rack.id not found when the broker is not found in zk for some reason. I reproduced the problem by starting docker-compose and then stopping one container:

```
Topics:
  test1
  test2

Broker change summary:
  Previous broker 1003 missing
  Broker 1003 does not have a rack.id defined
  -
  Replacing 0, added 0, missing 1, total count changed by 0

Action:
  no-op

Partition map changes:
  test1 p0: [1003 1001 1002] -> [1001 1002] decreased replication, replaced broker
  test2 p0: [1001 1002] -> [1001 1002] no-op
  test2 p1: [1002 1003] -> [1002] decreased replication

Broker distribution:
  degree [min/max/avg]: 2/2/2.00 -> 1/1/1.00
  -
  Broker 1001 - leader: 2, follower: 0, total: 2
  Broker 1002 - leader: 1, follower: 2, total: 3

WARN:
  1 provided broker(s) do(es) not have a rack.id defined
  1 provided brokers not found in ZooKeeper
  test1 p0: No additional brokers that meet Constraints
  test2 p1: No additional brokers that meet Constraints

  Warnings encountered, partition map not created. Override with --ignore-warns.
```


This is after the fix:
```
Topics:
  test1
  test2

Broker change summary:
  Previous broker 1003 missing
  -
  Replacing 0, added 0, missing 1, total count changed by 0

Action:
  no-op

Partition map changes:
  test1 p0: [1003 1001 1002] -> [1001 1002] decreased replication, replaced broker
  test2 p0: [1001 1002] -> [1001 1002] no-op
  test2 p1: [1002 1003] -> [1002] decreased replication

Broker distribution:
  degree [min/max/avg]: 2/2/2.00 -> 1/1/1.00
  -
  Broker 1001 - leader: 2, follower: 0, total: 2
  Broker 1002 - leader: 1, follower: 2, total: 3

WARN:
  1 provided brokers not found in ZooKeeper
  test1 p0: No additional brokers that meet Constraints
  test2 p1: No additional brokers that meet Constraints

  Warnings encountered, partition map not created. Override with --ignore-warns.
```