### PR TITLE
[docker-compose] Add internal/external listeners for kafka

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,16 @@ services:
     image: wurstmeister/kafka:${KAFKA_VERSION:-2.11-0.10.2.2}
     ports:
       - "9092"
+      - "9093"
     depends_on:
       - zookeeper
     environment:
-      KAFKA_LISTENERS: PLAINTEXT://:9092
+      HOSTNAME_COMMAND: "docker-machine ip 2>/dev/null || echo 0.0.0.0"
+      PORT_COMMAND: "docker port $$(hostname) 9093/tcp | cut -d: -f2"
+      KAFKA_LISTENERS: INTERNAL://:9092,EXTERNAL://:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://:9092,EXTERNAL://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT, EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CREATE_TOPICS: "test1:1:3,test2:2:2"
       KAFKA_BROKER_RACK: 1a


### PR DESCRIPTION
This is useful for testing producers/consumers outside docker network.