### PR TITLE
avoids unecessary duplicate map file output

### DIFF
--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -261,6 +261,10 @@ func writeMaps(cmd *cobra.Command, pm *kafkazk.PartitionMap, phasedPM *kafkazk.P
 	// Write global map if set.
 	if outFile != "" {
 		for i, m := range outputMaps {
+			if m == nil {
+				continue
+			}
+
 			fullPath := fmt.Sprintf("%s%s%s", outPath, outFile, phaseSuffix[i])
 			err := kafkazk.WriteMap(m, fullPath)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/kafka-kit
 go 1.13
 
 require (
+	github.com/Datadog/kafka-kit v2.1.0+incompatible // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/confluentinc/confluent-kafka-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Datadog/kafka-kit v2.1.0+incompatible h1:i3Txw7gmstP9qXZIf1ulNucjSdSMWyxSyL22XephfxM=
+github.com/Datadog/kafka-kit v2.1.0+incompatible/go.mod h1:AX8ofZynFbkyKo/kY07Pm+PkHwiFHItJPE44MkDQdWU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=


### PR DESCRIPTION
#281 introduced a cosmetic bug that results in double output for combined maps:

```
New partition maps:
  combined.json [combined map]
  combined.json [combined map]
  test_topic.json
```

There's two writes for the scenario that `--phased-reassignments` is enabled, but it still writes two copies of a standard combined map when feature is disabled. It's cosmetic because the last write wins, which is the correct map when not using the feature.

This PR skips the double write.