### PR TITLE
[Registry] Rename SSLCACertPath to SSLCALocation

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -35,7 +35,7 @@ func main() {
 	flag.StringVar(&zkConfig.Prefix, "zk-prefix", "", "ZooKeeper prefix (if Kafka is configured with a chroot path prefix)")
 	flag.StringVar(&adminConfig.BootstrapServers, "bootstrap-servers", "localhost", "Kafka bootstrap servers")
 	flag.BoolVar(&adminConfig.SSLEnabled, "kafka-ssl-enabled", false, "Enable SSL encryption for kafka")
-	flag.StringVar(&adminConfig.SSLCACertPath, "kafka-ca-cert-path", "", "CA certificate path (.pem/.crt) for verifying broker's identity")
+	flag.StringVar(&adminConfig.SSLCALocation, "kafka-ca-location", "", "CA certificate path (.pem/.crt) for verifying broker's identity")
 	kafkaVersionString := flag.String("kafka-version", "v0.10.2", "Kafka release (Semantic Versioning)")
 
 	envy.Parse("REGISTRY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       REGISTRY_HTTP_LISTEN: 0.0.0.0:8080
       REGISTRY_GRPC_LISTEN: 0.0.0.0:8090
       REGISTRY_KAFKA_SSL_ENABLED: "true"
-      REGISTRY_KAFKA_CA_CERT_PATH: "/etc/kafka/config/kafka-ca-crt.pem"
+      REGISTRY_KAFKA_CA_LOCATION: "/etc/kafka/config/kafka-ca-crt.pem"
     volumes:
       - "ssl-store:/etc/kafka/config"
 

--- a/kafkaadmin/kafkaadmin.go
+++ b/kafkaadmin/kafkaadmin.go
@@ -20,7 +20,7 @@ type Client struct {
 type Config struct {
 	BootstrapServers string
 	SSLEnabled       bool
-	SSLCACertPath    string
+	SSLCALocation    string
 }
 
 // NewClient returns a new Client.
@@ -42,10 +42,10 @@ func newClient(cfg Config, factory FactoryFunc) (*Client, error) {
 
 	if cfg.SSLEnabled {
 		kafkaCfg.SetKey("security.protocol", "SSL")
-		if cfg.SSLCACertPath == "" {
-			return nil, fmt.Errorf("kafka SSL is enabled but SSLCACertPath was not provided")
+		if cfg.SSLCALocation == "" {
+			return nil, fmt.Errorf("kafka SSL is enabled but SSLCALocation was not provided")
 		}
-		kafkaCfg.SetKey("ssl.ca.location", cfg.SSLCACertPath)
+		kafkaCfg.SetKey("ssl.ca.location", cfg.SSLCALocation)
 	}
 
 	k, err := factory(kafkaCfg)

--- a/kafkaadmin/kafkaadmin_test.go
+++ b/kafkaadmin/kafkaadmin_test.go
@@ -25,7 +25,7 @@ func TestNewClientWithSSLEnabled(t *testing.T) {
 		},
 	).Return(&kafka.AdminClient{}, nil)
 	_, err := NewClientWithFactory(
-		Config{BootstrapServers: "kafka:9092", SSLEnabled: true, SSLCACertPath: "/etc/kafka/config/ca.crt"},
+		Config{BootstrapServers: "kafka:9092", SSLEnabled: true, SSLCALocation: "/etc/kafka/config/ca.crt"},
 		mkac.NewAdminClient,
 	)
 	assert.Nil(t, err)

--- a/registry/admin/admin.go
+++ b/registry/admin/admin.go
@@ -14,7 +14,7 @@ type Config struct {
 	Type             string
 	BootstrapServers string
 	SSLEnabled       bool
-	SSLCACertPath    string
+	SSLCALocation    string
 }
 
 // CreateTopicConfig holds CreateTopic parameters.

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -194,7 +194,7 @@ func (s *Server) InitKafkaAdmin(ctx context.Context, wg *sync.WaitGroup, cfg adm
 			kafkaadmin.Config{
 				BootstrapServers: cfg.BootstrapServers,
 				SSLEnabled:       cfg.SSLEnabled,
-				SSLCACertPath:    cfg.SSLCACertPath,
+				SSLCALocation:    cfg.SSLCALocation,
 			})
 		if err != nil {
 			return err


### PR DESCRIPTION
Renaming to use the same name provided to the kafkaAdminClient.