### PR TITLE
[autothrottle] prevent extra destination inclusions

### DIFF
--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -291,9 +291,11 @@ func getReassigningBrokers(r kafkazk.Reassignments, zk kafkazk.Handler) (reassig
 
 				// Dest brokers.
 				for _, b := range reassigning {
-					// Checks: not the leader, not -1 (offline/missing), not in the
-					// curent ISR state.
-					if b != leader && b != -1 && !inSlice(b, tstate[p].ISR) {
+					// Checks:  not -1 (offline/missing), not in the curent ISR state.
+					// XXX(jamie): out of sync but previously existing brokers would
+					// show here as well. May want to consider whether those should
+					// be dynamically throttled as if they're part of a reassignemnt.
+					if b != -1 && !inSlice(b, tstate[p].ISR) {
 						lb.dst[b] = struct{}{}
 						followers := lb.throttledReplicas[topic]["followers"]
 						lb.throttledReplicas[topic]["followers"] = append(followers, fmt.Sprintf("%d:%d", partn, b))

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -274,7 +274,8 @@ func getReassigningBrokers(r kafkazk.Reassignments, zk kafkazk.Handler) (reassig
 
 		// For each partition, compare the current ISR leader to the brokers being
 		// assigned in the reassignments. The current leaders will be sources,
-		// new brokers in the assignment list will be destinations.
+		// new brokers in the assignment list (but not in the current ISR state)
+		// will be destinations.
 		for p := range tstate {
 			partn, _ := strconv.Atoi(p)
 			if reassigning, exists := r[t][partn]; exists {
@@ -290,7 +291,9 @@ func getReassigningBrokers(r kafkazk.Reassignments, zk kafkazk.Handler) (reassig
 
 				// Dest brokers.
 				for _, b := range reassigning {
-					if b != leader && b != -1 {
+					// Checks: not the leader, not -1 (offline/missing), not in the
+					// curent ISR state.
+					if b != leader && b != -1 && !inSlice(b, tstate[p].ISR) {
 						lb.dst[b] = struct{}{}
 						followers := lb.throttledReplicas[topic]["followers"]
 						lb.throttledReplicas[topic]["followers"] = append(followers, fmt.Sprintf("%d:%d", partn, b))
@@ -694,4 +697,15 @@ func roleFromIndex(i int) string {
 	}
 
 	return "follower"
+}
+
+func inSlice(id int, s []int) bool {
+	found := false
+	for _, i := range s {
+		if id == i {
+			found = true
+		}
+	}
+
+	return found
 }

--- a/cmd/autothrottle/throttles_test.go
+++ b/cmd/autothrottle/throttles_test.go
@@ -82,8 +82,8 @@ func TestGetReassigningBrokers(t *testing.T) {
 	bmaps, _ := getReassigningBrokers(re, zk)
 
 	srcExpected := []int{1000, 1002}
-	dstExpected := []int{1003, 1004, 1005, 1010}
-	allExpected := []int{1000, 1002, 1003, 1004, 1005, 1010}
+	dstExpected := []int{1003, 1005, 1010}
+	allExpected := []int{1000, 1002, 1003, 1005, 1010}
 
 	// Inclusion checks.
 
@@ -128,7 +128,7 @@ func TestGetReassigningBrokers(t *testing.T) {
 	// Check throttled strings.
 
 	expectedThrottledLeaders := []string{"0:1000", "1:1002"}
-	expectedThrottledFollowers := []string{"0:1003", "0:1004", "1:1005", "1:1010"}
+	expectedThrottledFollowers := []string{"0:1003", "1:1005", "1:1010"}
 
 	throttledList := bmaps.throttledReplicas["mock"]["leaders"]
 	sort.Strings(throttledList)
@@ -145,17 +145,6 @@ func TestGetReassigningBrokers(t *testing.T) {
 			t.Errorf("Expected follower string '%s', got '%s'", expectedThrottledFollowers[n], s)
 		}
 	}
-}
-
-func inSlice(id int, s []int) bool {
-	found := false
-	for _, i := range s {
-		if id == i {
-			found = true
-		}
-	}
-
-	return found
 }
 
 func TestBrokerReplicationCapacities(t *testing.T) {

--- a/kafkazk/zookeeper_mocks.go
+++ b/kafkazk/zookeeper_mocks.go
@@ -8,14 +8,13 @@ import (
 // Mock mocks the Handler interface.
 type Mock struct{}
 
-// Many of these methods aren't complete
-// mocks as they haven't been needed.
+// Many of these methods aren't complete mocks as they haven't been needed.
 
 // GetReassignments mocks GetReassignments.
 func (zk *Mock) GetReassignments() Reassignments {
 	r := Reassignments{
 		"mock": map[int][]int{
-			0: []int{1003, 1004},
+			0: []int{1003, 1000, 1002},
 			1: []int{1005, 1010},
 		},
 	}


### PR DESCRIPTION
It was noticed that in some scenarios that source brokers (those sending partition data out) were also included in the destination brokers (those receiving partition data) list. This doesn't cause any immediate issue, but does add extra Kafka state propagation through ZK, plus it's simply incorrect.

The following log was observed:

```
Apr 01 18:37:26 i-xxx autothrottle[16266]: 2020/04/01 18:37:26 Topics with ongoing reassignments: [some_topic]
Apr 01 18:37:26 i-xxx autothrottle[16266]: 2020/04/01 18:37:26 Source brokers participating in replication: [1454 1456 1461 1463 1471 1479 1490 1492 1493 1525]
Apr 01 18:37:26 i-xxx autothrottle[16266]: 2020/04/01 18:37:26 Destination brokers participating in replication: [1456 1457 1458 1461 1462 1463 1474 1477 1479 1480 1487 1488 1489 1490 1492 1496 1525 1527]
```

Where _only_ broker ID `1527` should have been in the destination list. Examining the ZooKeeper state for a particular partition (4) , we have the following two entries:

Reassigning partitions configuration: `"partition":4,"replicas":[1527,1492,1463]`
Actual ISR state for partition 4: `[1471,1492,1463]`

In set-builder notation, the destinations should be `{x | x ∈ R ∧ x ∉ I }` where `R` is reassigning and `I` is the current ISR. Currently, the condition is effectively only that `x != I[0]` (ie is the leader, or index 0 of the ISR).

This was previously missed in testing where since the replica set len of 2 (replication factor <= 2) because if we have only 2 IDs and one is the leader, which is removed, then we add all remaining brokers to the destinations list, the only option _is_ the reassigning broker. This fails once the replica sen len exceeds 2 (replication factor >= 3).
