### PR TITLE
[registry] Add SASL support for kafka auth

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 
+	"github.com/DataDog/kafka-kit/kafkaadmin"
 	"github.com/DataDog/kafka-kit/kafkazk"
 	"github.com/DataDog/kafka-kit/registry/admin"
 	"github.com/DataDog/kafka-kit/registry/server"
@@ -25,6 +27,15 @@ func main() {
 	zkConfig := kafkazk.Config{}
 	adminConfig := admin.Config{Type: "kafka"}
 
+	securityProtocols := make([]string, 0, len(kafkaadmin.SecurityProtocolSet))
+	for k := range kafkaadmin.SecurityProtocolSet {
+		securityProtocols = append(securityProtocols, k)
+	}
+	saslMechanims := make([]string, 0, len(kafkaadmin.SASLMechanismSet))
+	for k := range kafkaadmin.SASLMechanismSet {
+		saslMechanims = append(saslMechanims, k)
+	}
+
 	v := flag.Bool("version", false, "version")
 	flag.StringVar(&serverConfig.HTTPListen, "http-listen", "localhost:8080", "Server HTTP listen address")
 	flag.StringVar(&serverConfig.GRPCListen, "grpc-listen", "localhost:8090", "Server gRPC listen address")
@@ -34,8 +45,12 @@ func main() {
 	flag.StringVar(&zkConfig.Connect, "zk-addr", "localhost:2181", "ZooKeeper connect string")
 	flag.StringVar(&zkConfig.Prefix, "zk-prefix", "", "ZooKeeper prefix (if Kafka is configured with a chroot path prefix)")
 	flag.StringVar(&adminConfig.BootstrapServers, "bootstrap-servers", "localhost", "Kafka bootstrap servers")
-	flag.BoolVar(&adminConfig.SSLEnabled, "kafka-ssl-enabled", false, "Enable SSL encryption for kafka")
-	flag.StringVar(&adminConfig.SSLCALocation, "kafka-ca-location", "", "CA certificate path (.pem/.crt) for verifying broker's identity")
+	flag.StringVar(&adminConfig.SecurityProtocol, "kafka-security-protocol", "PLAINTEXT", fmt.Sprintf("Protocol used to communicate with brokers. Supported: %s", strings.Join(securityProtocols, ", ")))
+	flag.StringVar(&adminConfig.SSLCALocation, "kafka-ssl-ca-location", "", "CA certificate path (.pem/.crt) for verifying broker's identity. Needed for SSL and SASL_SSL protocols.")
+	flag.StringVar(&adminConfig.SASLMechanism, "kafka-sasl-mechanism", "", fmt.Sprintf("SASL mechanism to use for authentication. Supported: %s", strings.Join(saslMechanims, ", ")))
+	flag.StringVar(&adminConfig.SASLUsername, "kafka-sasl-username", "", "SASL username for use with the PLAIN and SASL-SCRAM-* mechanisms")
+	flag.StringVar(&adminConfig.SASLPassword, "kafka-sasl-password", "", "SASL password for use with the PLAIN and SASL-SCRAM-* mechanisms")
+
 	kafkaVersionString := flag.String("kafka-version", "v0.10.2", "Kafka release (Semantic Versioning)")
 
 	envy.Parse("REGISTRY")
@@ -49,6 +64,18 @@ func main() {
 	_, err := semver.NewVersion(*kafkaVersionString)
 	if err != nil {
 		fmt.Printf("Invalid SemVer: %s\n", *kafkaVersionString)
+		os.Exit(1)
+	}
+
+	adminConfig.SecurityProtocol = strings.ToUpper(adminConfig.SecurityProtocol)
+	if _, validChoice := kafkaadmin.SecurityProtocolSet[adminConfig.SecurityProtocol]; !validChoice {
+		fmt.Printf("Invalid kafka security protocol. Supported protocols: %s\n", strings.Join(securityProtocols, ", "))
+		os.Exit(1)
+	}
+
+	adminConfig.SASLMechanism = strings.ToUpper(adminConfig.SASLMechanism)
+	if _, validChoice := kafkaadmin.SASLMechanismSet[adminConfig.SASLMechanism]; !validChoice {
+		fmt.Printf("Invalid kafka SASL mechanism. Supported mechanisms: %s\n", strings.Join(saslMechanims, ", "))
 		os.Exit(1)
 	}
 

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -45,7 +45,7 @@ func main() {
 	flag.StringVar(&zkConfig.Connect, "zk-addr", "localhost:2181", "ZooKeeper connect string")
 	flag.StringVar(&zkConfig.Prefix, "zk-prefix", "", "ZooKeeper prefix (if Kafka is configured with a chroot path prefix)")
 	flag.StringVar(&adminConfig.BootstrapServers, "bootstrap-servers", "localhost", "Kafka bootstrap servers")
-	flag.StringVar(&adminConfig.SecurityProtocol, "kafka-security-protocol", "PLAINTEXT", fmt.Sprintf("Protocol used to communicate with brokers. Supported: %s", strings.Join(securityProtocols, ", ")))
+	flag.StringVar(&adminConfig.SecurityProtocol, "kafka-security-protocol", "", fmt.Sprintf("Protocol used to communicate with brokers. Supported: %s", strings.Join(securityProtocols, ", ")))
 	flag.StringVar(&adminConfig.SSLCALocation, "kafka-ssl-ca-location", "", "CA certificate path (.pem/.crt) for verifying broker's identity. Needed for SSL and SASL_SSL protocols.")
 	flag.StringVar(&adminConfig.SASLMechanism, "kafka-sasl-mechanism", "", fmt.Sprintf("SASL mechanism to use for authentication. Supported: %s", strings.Join(saslMechanims, ", ")))
 	flag.StringVar(&adminConfig.SASLUsername, "kafka-sasl-username", "", "SASL username for use with the PLAIN and SASL-SCRAM-* mechanisms")
@@ -67,16 +67,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	adminConfig.SecurityProtocol = strings.ToUpper(adminConfig.SecurityProtocol)
-	if _, validChoice := kafkaadmin.SecurityProtocolSet[adminConfig.SecurityProtocol]; !validChoice {
-		fmt.Printf("Invalid kafka security protocol. Supported protocols: %s\n", strings.Join(securityProtocols, ", "))
-		os.Exit(1)
+	if adminConfig.SecurityProtocol != "" {
+		adminConfig.SecurityProtocol = strings.ToUpper(adminConfig.SecurityProtocol)
+		if _, validChoice := kafkaadmin.SecurityProtocolSet[adminConfig.SecurityProtocol]; !validChoice {
+			fmt.Printf("Invalid kafka security protocol. Supported protocols: %s\n", strings.Join(securityProtocols, ", "))
+			os.Exit(1)
+		}
 	}
 
-	adminConfig.SASLMechanism = strings.ToUpper(adminConfig.SASLMechanism)
-	if _, validChoice := kafkaadmin.SASLMechanismSet[adminConfig.SASLMechanism]; !validChoice {
-		fmt.Printf("Invalid kafka SASL mechanism. Supported mechanisms: %s\n", strings.Join(saslMechanims, ", "))
-		os.Exit(1)
+	if adminConfig.SASLMechanism != "" {
+		adminConfig.SASLMechanism = strings.ToUpper(adminConfig.SASLMechanism)
+		if _, validChoice := kafkaadmin.SASLMechanismSet[adminConfig.SASLMechanism]; !validChoice {
+			fmt.Printf("Invalid kafka SASL mechanism. Supported mechanisms: %s\n", strings.Join(saslMechanims, ", "))
+			os.Exit(1)
+		}
 	}
 
 	log.Println("Registry running")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,15 @@ services:
       - "9092"
       - "9093"
     depends_on:
+      - ssl_setup
       - zookeeper
     environment:
-      KAFKA_LISTENERS: PLAINTEXT://:9092, SSL://:9093
+      KAFKA_LISTENERS: SASL_SSL://:9093
       KAFKA_PORT: 9093
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CREATE_TOPICS: "test1:1:3,test2:2:2"
       KAFKA_BROKER_RACK: 1a
-      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "SSL"
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "SASL_SSL"
       KAFKA_SSL_KEYSTORE_LOCATION: "/etc/kafka/config/keystore.jks"
       KAFKA_SSL_KEYSTORE_PASSWORD: "password"
       KAFKA_SSL_KEYSTORE_TYPE: "JKS"
@@ -50,6 +51,15 @@ services:
       KAFKA_SSL_KEY_PASSWORD: "password"
       KAFKA_SSL_ENABLED_PROTOCOLS: "TLSv1.2"
       KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: ""
+      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
+      KAFKA_LISTENER_NAME_SASL_SSL_PLAIN_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.PlainLoginModule required \
+      username='admin' password='admin-secret' \
+      user_admin='admin-secret' \
+      user_registry='registry-secret';"
+      CUSTOM_INIT_SCRIPT: "sh -c \" \
+      sed -i 's/listener.name.sasl.ssl.plain.sasl.jaas.config/listener.name.sasl_ssl.plain.sasl.jaas.config/g' \
+      /opt/kafka/config/server.properties\""
       # useful for SSL debugging
       # LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER: "DEBUG, authorizerAppender"
       # KAFKA_OPTS: "-Djavax.net.debug=all"
@@ -72,8 +82,12 @@ services:
       REGISTRY_BOOTSTRAP_SERVERS: kafka:9093
       REGISTRY_HTTP_LISTEN: 0.0.0.0:8080
       REGISTRY_GRPC_LISTEN: 0.0.0.0:8090
-      REGISTRY_KAFKA_SSL_ENABLED: "true"
-      REGISTRY_KAFKA_CA_LOCATION: "/etc/kafka/config/kafka-ca-crt.pem"
+      REGISTRY_KAFKA_SECURITY_PROTOCOL: SASL_SSL
+      REGISTRY_KAFKA_SSL_CA_LOCATION: "/etc/kafka/config/kafka-ca-crt.pem"
+      REGISTRY_KAFKA_SASL_MECHANISM: PLAIN
+      REGISTRY_KAFKA_SASL_USERNAME: registry
+      REGISTRY_KAFKA_SASL_PASSWORD: registry-secret
+
     volumes:
       - "ssl-store:/etc/kafka/config"
 

--- a/kafkaadmin/kafkaadmin.go
+++ b/kafkaadmin/kafkaadmin.go
@@ -49,7 +49,10 @@ func newClient(cfg Config, factory FactoryFunc) (*Client, error) {
 
 	kafkaCfg := &kafka.ConfigMap{
 		"bootstrap.servers": cfg.BootstrapServers,
-		"security.protocol": cfg.SecurityProtocol,
+	}
+
+	if cfg.SecurityProtocol != "" {
+		kafkaCfg.SetKey("security.protocol", cfg.SecurityProtocol)
 	}
 
 	if cfg.SecurityProtocol == "SSL" || cfg.SecurityProtocol == "SASL_SSL" {

--- a/kafkaadmin/kafkaadmin.go
+++ b/kafkaadmin/kafkaadmin.go
@@ -47,13 +47,9 @@ func NewClientWithFactory(cfg Config, factory FactoryFunc) (*Client, error) {
 func newClient(cfg Config, factory FactoryFunc) (*Client, error) {
 	c := &Client{}
 
-	fmt.Printf("config: %v\n", cfg)
 	kafkaCfg := &kafka.ConfigMap{
 		"bootstrap.servers": cfg.BootstrapServers,
 		"security.protocol": cfg.SecurityProtocol,
-		"sasl.mechanism":    cfg.SASLMechanism,
-		"sasl.username":     cfg.SASLUsername,
-		"sasl.password":     cfg.SASLPassword,
 	}
 
 	if cfg.SecurityProtocol == "SSL" || cfg.SecurityProtocol == "SASL_SSL" {
@@ -61,6 +57,12 @@ func newClient(cfg Config, factory FactoryFunc) (*Client, error) {
 			return nil, fmt.Errorf("kafka %s is enabled but SSLCALocation was not provided", cfg.SecurityProtocol)
 		}
 		kafkaCfg.SetKey("ssl.ca.location", cfg.SSLCALocation)
+	}
+
+	if cfg.SecurityProtocol == "SASL_SSL" {
+		kafkaCfg.SetKey("sasl.mechanism", cfg.SASLMechanism)
+		kafkaCfg.SetKey("sasl.username", cfg.SASLUsername)
+		kafkaCfg.SetKey("sasl.password", cfg.SASLPassword)
 	}
 
 	k, err := factory(kafkaCfg)

--- a/kafkaadmin/kafkaadmin_test.go
+++ b/kafkaadmin/kafkaadmin_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNewClient(t *testing.T) {
 	mkac := &MockedKafkaAdminClient{}
-	mkac.On("NewAdminClient", &kafka.ConfigMap{"bootstrap.servers": "kafka:9092"}).Return(&kafka.AdminClient{}, nil)
-	_, err := NewClientWithFactory(Config{BootstrapServers: "kafka:9092"}, mkac.NewAdminClient)
+	mkac.On("NewAdminClient", &kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "security.protocol": "PLAINTEXT"}).Return(&kafka.AdminClient{}, nil)
+	_, err := NewClientWithFactory(Config{BootstrapServers: "kafka:9092", SecurityProtocol: "PLAINTEXT"}, mkac.NewAdminClient)
 	assert.Nil(t, err)
 	mkac.AssertExpectations(t)
 }

--- a/kafkaadmin/kafkaadmin_test.go
+++ b/kafkaadmin/kafkaadmin_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNewClient(t *testing.T) {
 	mkac := &MockedKafkaAdminClient{}
-	mkac.On("NewAdminClient", &kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "security.protocol": "PLAINTEXT"}).Return(&kafka.AdminClient{}, nil)
-	_, err := NewClientWithFactory(Config{BootstrapServers: "kafka:9092", SecurityProtocol: "PLAINTEXT"}, mkac.NewAdminClient)
+	mkac.On("NewAdminClient", &kafka.ConfigMap{"bootstrap.servers": "kafka:9092"}).Return(&kafka.AdminClient{}, nil)
+	_, err := NewClientWithFactory(Config{BootstrapServers: "kafka:9092"}, mkac.NewAdminClient)
 	assert.Nil(t, err)
 	mkac.AssertExpectations(t)
 }

--- a/kafkaadmin/kafkaadmin_test.go
+++ b/kafkaadmin/kafkaadmin_test.go
@@ -20,12 +20,39 @@ func TestNewClientWithSSLEnabled(t *testing.T) {
 	mkac.On("NewAdminClient",
 		&kafka.ConfigMap{
 			"bootstrap.servers": "kafka:9092",
-			"security.protocol": "SSL",
 			"ssl.ca.location":   "/etc/kafka/config/ca.crt",
+			"security.protocol": "SSL",
 		},
 	).Return(&kafka.AdminClient{}, nil)
 	_, err := NewClientWithFactory(
-		Config{BootstrapServers: "kafka:9092", SSLEnabled: true, SSLCALocation: "/etc/kafka/config/ca.crt"},
+		Config{BootstrapServers: "kafka:9092", SSLCALocation: "/etc/kafka/config/ca.crt", SecurityProtocol: "SSL"},
+		mkac.NewAdminClient,
+	)
+	assert.Nil(t, err)
+	mkac.AssertExpectations(t)
+}
+
+func TestNewClientWithSASLEnabled(t *testing.T) {
+	mkac := &MockedKafkaAdminClient{}
+	mkac.On("NewAdminClient",
+		&kafka.ConfigMap{
+			"bootstrap.servers": "kafka:9092",
+			"ssl.ca.location":   "/etc/kafka/config/ca.crt",
+			"security.protocol": "SASL_SSL",
+			"sasl.mechanism":    "PLAIN",
+			"sasl.username":     "registry",
+			"sasl.password":     "secret",
+		},
+	).Return(&kafka.AdminClient{}, nil)
+	_, err := NewClientWithFactory(
+		Config{
+			BootstrapServers: "kafka:9092",
+			SSLCALocation:    "/etc/kafka/config/ca.crt",
+			SecurityProtocol: "SASL_SSL",
+			SASLMechanism:    "PLAIN",
+			SASLUsername:     "registry",
+			SASLPassword:     "secret",
+		},
 		mkac.NewAdminClient,
 	)
 	assert.Nil(t, err)

--- a/registry/admin/admin.go
+++ b/registry/admin/admin.go
@@ -13,8 +13,11 @@ type Client interface {
 type Config struct {
 	Type             string
 	BootstrapServers string
-	SSLEnabled       bool
 	SSLCALocation    string
+	SecurityProtocol string
+	SASLMechanism    string
+	SASLUsername     string
+	SASLPassword     string
 }
 
 // CreateTopicConfig holds CreateTopic parameters.

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -193,8 +193,11 @@ func (s *Server) InitKafkaAdmin(ctx context.Context, wg *sync.WaitGroup, cfg adm
 		k, err := kafkaadmin.NewClient(
 			kafkaadmin.Config{
 				BootstrapServers: cfg.BootstrapServers,
-				SSLEnabled:       cfg.SSLEnabled,
 				SSLCALocation:    cfg.SSLCALocation,
+				SecurityProtocol: cfg.SecurityProtocol,
+				SASLMechanism:    cfg.SASLMechanism,
+				SASLUsername:     cfg.SASLUsername,
+				SASLPassword:     cfg.SASLPassword,
 			})
 		if err != nil {
 			return err


### PR DESCRIPTION
This adds support for Kafka auth via SASL to the registry.