### PR TITLE
make kafka-kit usable as a go module

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -41,7 +41,7 @@ COPY registry registry
 
 # Build.
 RUN protoc -I registry -I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis protos/registry.proto --go_out=plugins=grpc:registry --grpc-gateway_out=logtostderr=true:registry
-RUN go install github.com/DataDog/kafka-kit/cmd/registry
+RUN go install ./cmd/registry
 
 # Runtime.
 EXPOSE 8090/tcp

--- a/cmd/autothrottle/api.go
+++ b/cmd/autothrottle/api.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // APIConfig holds configuration params for the admin API.

--- a/cmd/autothrottle/api_deprecated.go
+++ b/cmd/autothrottle/api_deprecated.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 var errDeprecated = "WARN: this route is deprecated - refer to documentation\n"

--- a/cmd/autothrottle/brokers.go
+++ b/cmd/autothrottle/brokers.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // reassigningBrokers holds several sets of brokers participating

--- a/cmd/autothrottle/brokers_test.go
+++ b/cmd/autothrottle/brokers_test.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 func TestGetReassigningBrokers(t *testing.T) {

--- a/cmd/autothrottle/capacities.go
+++ b/cmd/autothrottle/capacities.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 )
 
 // replicationCapacityByBroker is a mapping of broker ID to capacity.

--- a/cmd/autothrottle/capacities_test.go
+++ b/cmd/autothrottle/capacities_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 func TestBrokerReplicationCapacities(t *testing.T) {

--- a/cmd/autothrottle/events.go
+++ b/cmd/autothrottle/events.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 )
 
 // Events configs.

--- a/cmd/autothrottle/limits.go
+++ b/cmd/autothrottle/limits.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 )
 
 // Limits is a map of instance-type to network bandwidth limits.

--- a/cmd/autothrottle/limits_test.go
+++ b/cmd/autothrottle/limits_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 )
 
 func TestNewLimits(t *testing.T) {

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
-	"github.com/DataDog/kafka-kit/kafkametrics/datadog"
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics/datadog"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/jamiealquiza/envy"
 )

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/DataDog/kafka-kit/kafkametrics"
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // ReplicationThrottleConfigs holds all the data needed to call

--- a/cmd/autothrottle/throttles_persistence.go
+++ b/cmd/autothrottle/throttles_persistence.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 var (

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // brokerChangeEvent is the message type returned in the events channel

--- a/cmd/metricsfetcher/main.go
+++ b/cmd/metricsfetcher/main.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/jamiealquiza/envy"
 	dd "github.com/zorkian/go-datadog-api"

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/kafka-kit/kafkaadmin"
-	"github.com/DataDog/kafka-kit/kafkazk"
-	"github.com/DataDog/kafka-kit/registry/admin"
-	"github.com/DataDog/kafka-kit/registry/server"
+	"github.com/DataDog/kafka-kit/v3/kafkaadmin"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/registry/admin"
+	"github.com/DataDog/kafka-kit/v3/registry/server"
 
 	"github.com/jamiealquiza/envy"
 	"github.com/masterminds/semver"

--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/rebalance_steps.go
+++ b/cmd/topicmappr/commands/rebalance_steps.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/topicmappr/commands/rebuild_steps_test.go
+++ b/cmd/topicmappr/commands/rebuild_steps_test.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 func TestNotInReplicaSet(t *testing.T) {

--- a/cmd/topicmappr/commands/version.go
+++ b/cmd/topicmappr/commands/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // This can be set with
-// -ldflags "-X github.com/DataDog/kafka-kit/cmd/topicmappr/commands.version=x.x.x"
+// -ldflags "-X github.com/DataDog/kafka-kit/v3/cmd/topicmappr/commands.version=x.x.x"
 var version = "0.0.0"
 
 func init() {

--- a/cmd/topicmappr/main.go
+++ b/cmd/topicmappr/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/DataDog/kafka-kit/cmd/topicmappr/commands"
+import "github.com/DataDog/kafka-kit/v3/cmd/topicmappr/commands"
 
 func main() {
 	commands.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/kafka-kit
+module github.com/DataDog/kafka-kit/v3
 
 go 1.13
 

--- a/kafkaadmin/kafkaadmin.go
+++ b/kafkaadmin/kafkaadmin.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/kafka-kit/registry/admin"
+	"github.com/DataDog/kafka-kit/v3/registry/admin"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )

--- a/kafkametrics/datadog/datadog.go
+++ b/kafkametrics/datadog/datadog.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 
 	dd "github.com/zorkian/go-datadog-api"
 )

--- a/kafkametrics/datadog/metrics.go
+++ b/kafkametrics/datadog/metrics.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 
 	dd "github.com/zorkian/go-datadog-api"
 )

--- a/kafkametrics/datadog/metrics_test.go
+++ b/kafkametrics/datadog/metrics_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkametrics"
+	"github.com/DataDog/kafka-kit/v3/kafkametrics"
 )
 
 func TestMergeBrokerLists(t *testing.T) {

--- a/registry/server/api_brokers.go
+++ b/registry/server/api_brokers.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 var (

--- a/registry/server/api_brokers_test.go
+++ b/registry/server/api_brokers_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 func TestGetBrokers(t *testing.T) {

--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"sort"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
-	"github.com/DataDog/kafka-kit/registry/admin"
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/registry/admin"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 var (

--- a/registry/server/api_topics_test.go
+++ b/registry/server/api_topics_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 func TestGetTopics(t *testing.T) {

--- a/registry/server/helpers_test.go
+++ b/registry/server/helpers_test.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 var (

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -11,10 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkaadmin"
-	"github.com/DataDog/kafka-kit/kafkazk"
-	"github.com/DataDog/kafka-kit/registry/admin"
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	"github.com/DataDog/kafka-kit/v3/kafkaadmin"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/registry/admin"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"

--- a/registry/server/tag.go
+++ b/registry/server/tag.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 var (

--- a/registry/server/tag_test.go
+++ b/registry/server/tag_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	pb "github.com/DataDog/kafka-kit/registry/protos"
+	pb "github.com/DataDog/kafka-kit/v3/registry/protos"
 )
 
 func TestTagSetFromObject(t *testing.T) {

--- a/registry/server/tagstorage_zk.go
+++ b/registry/server/tagstorage_zk.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // ZKTagStorage implements tag persistence in ZooKeeper.

--- a/registry/server/tagstorage_zk_mock.go
+++ b/registry/server/tagstorage_zk_mock.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 // zkTagStorageMockMock mocks ZKTagStorage.

--- a/registry/server/tagstorage_zk_test.go
+++ b/registry/server/tagstorage_zk_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/DataDog/kafka-kit/kafkazk"
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
 var (


### PR DESCRIPTION
avoids:

```
$ go get -u github.com/DataDog/kafka-kit@v3.2.0
go get github.com/DataDog/kafka-kit@v3.2.0: github.com/DataDog/kafka-kit@v3.2.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```