### PR TITLE
jamie/autothrottle repairing topics

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -34,8 +34,9 @@ WORKDIR /go/src/github.com/DataDog/kafka-kit
 COPY go.mod go.mod
 RUN go mod download
 
-COPY cmd/registry cmd/registry
+COPY cmd cmd
 COPY kafkaadmin kafkaadmin
+COPY kafkametrics kafkametrics
 COPY kafkazk kafkazk
 COPY registry registry
 

--- a/cmd/autothrottle/api_parsing.go
+++ b/cmd/autothrottle/api_parsing.go
@@ -14,6 +14,7 @@ var (
 	errRateParamUnspecified = errors.New("rate param must be specified")
 	errRateParamIsZero      = errors.New("rate param must be >0")
 	errRateParamNotInt      = errors.New("rate param must be supplied as an integer")
+	errAutoRemoveNotBool    = errors.New("autoremove param must be a bool")
 )
 
 // parseRateParam takes a *http.Request and returns the specified
@@ -44,7 +45,7 @@ func parseAutoRemoveParam(req *http.Request) (bool, error) {
 	if c != "" {
 		autoRemove, err = strconv.ParseBool(c)
 		if err != nil {
-			return autoRemove, errors.New("autoremove param must be a bool")
+			return autoRemove, errAutoRemoveNotBool
 		}
 	}
 

--- a/cmd/autothrottle/api_parsing.go
+++ b/cmd/autothrottle/api_parsing.go
@@ -9,7 +9,12 @@ import (
 	"strings"
 )
 
-var errBrokerIDNotProvided = errors.New("broker ID not provided")
+var (
+	errBrokerIDNotProvided  = errors.New("broker ID not provided")
+	errRateParamUnspecified = errors.New("rate param must be specified")
+	errRateParamIsZero      = errors.New("rate param must be >0")
+	errRateParamNotInt      = errors.New("rate param must be supplied as an integer")
+)
 
 // parseRateParam takes a *http.Request and returns the specified
 // 'rate' request parameter formatted as a int.
@@ -19,11 +24,11 @@ func parseRateParam(req *http.Request) (int, error) {
 
 	switch {
 	case r == "":
-		return 0, errors.New("rate param must be specified")
+		return 0, errRateParamUnspecified
 	case r == "0":
-		return 0, errors.New("rate param must be >0")
+		return 0, errRateParamIsZero
 	case err != nil:
-		return 0, errors.New("rate param must be supplied as an integer")
+		return 0, errRateParamNotInt
 	}
 
 	return rate, nil

--- a/cmd/autothrottle/api_parsing_test.go
+++ b/cmd/autothrottle/api_parsing_test.go
@@ -120,3 +120,27 @@ func TestParsePaths(t *testing.T) {
 		}
 	}
 }
+
+func TestBrokerIDFromPath(t *testing.T) {
+	expected := 1234
+
+	// Test path for adding throttle.
+	url := fmt.Sprintf("http://localhost/throttle/%d", expected)
+	req, _ := http.NewRequest("POST", url, nil)
+
+	out, _ := brokerIDFromPath(req)
+
+	if out != expected {
+		t.Errorf("Expected broker ID '%d', got '%d'", expected, out)
+	}
+
+	// Test path for removing throttle.
+	url = fmt.Sprintf("http://localhost/throttle/remove/%d", expected)
+	req, _ = http.NewRequest("POST", url, nil)
+
+	out, _ = brokerIDFromPath(req)
+
+	if out != expected {
+		t.Errorf("Expected broker ID '%d', got '%d'", expected, out)
+	}
+}

--- a/cmd/autothrottle/api_parsing_test.go
+++ b/cmd/autothrottle/api_parsing_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestParseRateParam(t *testing.T) {
+	// Test all 4 conditions in parseRateParam.
+	var requests = [4]*http.Request{}
+
+	// Populate the requests array.
+	for i, rate := range []string{"", "0", "text", "100"} {
+		url := fmt.Sprintf("http://localhost?rate=%s", rate)
+		req, _ := http.NewRequest("POST", url, nil)
+		requests[i] = req
+	}
+
+	type response struct {
+		rate int
+		err  error
+	}
+
+	expected := []response{
+		response{
+			rate: 0,
+			err:  errRateParamUnspecified,
+		},
+		response{
+			rate: 0,
+			err:  errRateParamIsZero,
+		},
+		response{
+			rate: 0,
+			err:  errRateParamNotInt,
+		},
+		response{
+			rate: 100,
+			err:  nil,
+		},
+	}
+
+	for i := range requests {
+		rate, err := parseRateParam(requests[i])
+
+		if rate != expected[i].rate {
+			t.Errorf("Expected rate '%d', got '%d'", expected[i].rate, rate)
+		}
+
+		if err != expected[i].err {
+			t.Errorf("Expected error '%s', got '%s'", expected[i].err, err)
+		}
+	}
+}

--- a/cmd/autothrottle/api_parsing_test.go
+++ b/cmd/autothrottle/api_parsing_test.go
@@ -53,3 +53,51 @@ func TestParseRateParam(t *testing.T) {
 		}
 	}
 }
+
+func TestParseAutoRemoveParam(t *testing.T) {
+	var requests = [3]*http.Request{}
+
+	url := "http://localhost?autoremove=text"
+	req, _ := http.NewRequest("POST", url, nil)
+	requests[0] = req
+
+	url = fmt.Sprintf("http://localhost?autoremove=%v", true)
+	req, _ = http.NewRequest("POST", url, nil)
+	requests[1] = req
+
+	url = fmt.Sprintf("http://localhost?autoremove=%v", false)
+	req, _ = http.NewRequest("POST", url, nil)
+	requests[2] = req
+
+	type response struct {
+		autoRemove bool
+		err        error
+	}
+
+	expected := []response{
+		response{
+			autoRemove: false,
+			err:        errAutoRemoveNotBool,
+		},
+		response{
+			autoRemove: true,
+			err:        nil,
+		},
+		response{
+			autoRemove: false,
+			err:        nil,
+		},
+	}
+
+	for i := range requests {
+		autoRemove, err := parseAutoRemoveParam(requests[i])
+
+		if autoRemove != expected[i].autoRemove {
+			t.Errorf("Expected bool '%v', got '%v'", expected[i].autoRemove, autoRemove)
+		}
+
+		if err != expected[i].err {
+			t.Errorf("Expected error '%s', got '%s'", expected[i].err, err)
+		}
+	}
+}

--- a/cmd/autothrottle/api_parsing_test.go
+++ b/cmd/autothrottle/api_parsing_test.go
@@ -101,3 +101,22 @@ func TestParseAutoRemoveParam(t *testing.T) {
 		}
 	}
 }
+
+func TestParsePaths(t *testing.T) {
+	url := "http://localhost/throttle/add"
+	req, _ := http.NewRequest("POST", url, nil)
+
+	out := parsePaths(req)
+	expected := []string{"throttle", "add"}
+
+	if len(out) != len(expected) {
+		t.Fatalf("Expected len '%d', got '%d'", len(expected), len(out))
+	}
+
+	for i := range expected {
+		if out[i] != expected[i] {
+			t.Errorf("Expected output '%v', got '%v'", expected, out)
+			break
+		}
+	}
+}

--- a/cmd/autothrottle/brokers.go
+++ b/cmd/autothrottle/brokers.go
@@ -135,14 +135,12 @@ func roleFromIndex(i int) string {
 }
 
 func inSlice(id int, s []int) bool {
-	found := false
 	for _, i := range s {
 		if id == i {
-			found = true
+			return true
 		}
 	}
-
-	return found
+	return false
 }
 
 // incompleteBrokerMetrics takes a []int of all broker IDs involved in

--- a/cmd/autothrottle/brokers.go
+++ b/cmd/autothrottle/brokers.go
@@ -18,24 +18,6 @@ type reassigningBrokers struct {
 	throttledReplicas topicThrottledReplicas
 }
 
-// topicThrottledReplicas is a map of topic names to throttled types.
-// This is ultimately populated as follows:
-//   map[topic]map[leaders]["0:1001", "1:1002"]
-//   map[topic]map[followers]["2:1003", "3:1004"]
-type topicThrottledReplicas map[topic]throttled
-
-// throttled is a replica type (leader, follower) to replica list.
-type throttled map[replicaType]brokerIDs
-
-// topic name.
-type topic string
-
-// leader, follower.
-type replicaType string
-
-// Replica broker IDs as a []string.
-type brokerIDs []string
-
 // lists returns a sorted []int of broker IDs for the src, dst
 // and all brokers from a reassigningBrokers.
 func (bm reassigningBrokers) lists() ([]int, []int, []int) {

--- a/cmd/autothrottle/brokers.go
+++ b/cmd/autothrottle/brokers.go
@@ -76,6 +76,8 @@ func getReassigningBrokers(r kafkazk.Reassignments, zk kafkazk.Handler) (reassig
 		// assigned in the reassignments. The current leaders will be sources,
 		// new brokers in the assignment list (but not in the current ISR state)
 		// will be destinations.
+		// TODO(jamie): the throttledReplicas can be populated here with the recently
+		// added topicThrottledReplicas.addReplica method.
 		for p := range tstate {
 			partn, _ := strconv.Atoi(p)
 			if reassigning, exists := r[t][partn]; exists {

--- a/cmd/autothrottle/capacities_test.go
+++ b/cmd/autothrottle/capacities_test.go
@@ -57,3 +57,53 @@ func TestBrokerReplicationCapacities(t *testing.T) {
 func float64ptr(f float64) *float64 {
 	return &f
 }
+
+func TestStoreLeaderCapacity(t *testing.T) {
+	capacities := replicationCapacityByBroker{}
+
+	capacities.storeLeaderCapacity(1001, 100)
+	out := capacities[1001]
+
+	// Index 0 is the leader position.
+	val := out[0]
+
+	if val == nil {
+		t.Fatal("Unexpected nil value")
+	}
+
+	if *val != 100 {
+		t.Errorf("Expected value '100', got '%f'", *val)
+	}
+
+	// Index 1 is the follower position.
+	val = out[1]
+
+	if val != nil {
+		t.Errorf("Expected nil value, got %v", *val)
+	}
+}
+
+func TestStoreFollowerCapacity(t *testing.T) {
+	capacities := replicationCapacityByBroker{}
+
+	capacities.storeFollowerCapacity(1001, 100)
+	out := capacities[1001]
+
+	// Index 1 is the follower position.
+	val := out[1]
+
+	if val == nil {
+		t.Fatal("Unexpected nil value")
+	}
+
+	if *val != 100 {
+		t.Errorf("Expected value '100', got '%f'", *val)
+	}
+
+	// Index 0 is the leader position.
+	val = out[0]
+
+	if val != nil {
+		t.Errorf("Expected nil value, got %v", *val)
+	}
+}

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -337,6 +337,8 @@ func main() {
 			for i := range errs {
 				log.Println(errs[i])
 			}
+
+			knownThrottles = true
 		}
 
 		// If there's no topics being reassigned, clear any throttles marked

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -233,10 +233,6 @@ func main() {
 			log.Println(err)
 		}
 
-		// Get brokers with active overrides, ie where the override rate is non-0,
-		// that are also not part of a reassignment.
-		activeOverrideBrokers := throttleMeta.brokerOverrides.Filter(notReassignmentParticipant)
-
 		// Get the maps of brokers handling reassignments.
 		throttleMeta.reassigningBrokers, err = getReassigningBrokers(reassignments, zk)
 		if err != nil {
@@ -259,6 +255,10 @@ func main() {
 				knownThrottles = true
 			}
 		}
+
+		// Get brokers with active overrides, ie where the override rate is non-0,
+		// that are also not part of a reassignment.
+		activeOverrideBrokers := throttleMeta.brokerOverrides.Filter(notReassignmentParticipant)
 
 		// Apply any additional broker-specific throttles that were not applied as
 		// part of a reassignment.

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -315,17 +315,16 @@ func main() {
 			// dynamic configuration parameter. It's clumsy, but this is the way
 			// Kafka was designed.
 
-			// Get non-reassigning brokers with throttles
-			// Get topics by brokers
-			recovering, err := getRecoveringTopics(throttleMeta)
+			// Get a topicThrottledReplicas for all topics that have partition
+			// assignments to any brokers with overrides.
+			// TODO(jamie): is there a scenario where we should exclude topics
+			// have also have a reassignment? We're discovering topics here by
+			// reverse lookup of brokers that are not reassignment participants.
+			var err error
+			throttleMeta.overrideThrottleLists, err = getTopicsWithThrottledBrokers(throttleMeta)
 			if err != nil {
-				log.Println(err)
+				log.Printf("Error fetching topic states: %s\n", err)
 			}
-
-			_ = recovering
-
-			// Generate throttled replica configurations
-			// Pass to updateOverrideThrottles
 
 			if err := updateOverrideThrottles(throttleMeta); err != nil {
 				log.Println(err)

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -198,7 +198,7 @@ func main() {
 
 		// Check for topics that were previously seen replicating, but are no
 		// longer in this interval.
-		topicsDoneReplicating := topicsReplicatingNow.diff(topicsReplicatingPreviously)
+		topicsDoneReplicating := topicsReplicatingPreviously.diff(topicsReplicatingNow)
 
 		// Log and write event.
 		if len(topicsDoneReplicating) > 0 {
@@ -206,10 +206,6 @@ func main() {
 			log.Println(m)
 			events.Write("Topics done reassigning", m)
 		}
-
-		// Rebuild topicsReplicatingPreviously with the current replications
-		// for the next check iteration.
-		topicsReplicatingPreviously = topicsReplicatingNow.copy()
 
 		// If all of the currently replicating topics are a subset
 		// of the previously replicating topics, we can stop updating
@@ -220,6 +216,10 @@ func main() {
 		} else {
 			throttleMeta.EnableTopicUpdates()
 		}
+
+		// Rebuild topicsReplicatingPreviously with the current replications
+		// for the next check iteration.
+		topicsReplicatingPreviously = topicsReplicatingNow.copy()
 
 		// Check if a global throttle override was configured.
 		overrideCfg, err := fetchThrottleOverride(zk, overrideRateZnodePath)

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -299,9 +299,8 @@ func main() {
 				log.Println(err)
 			}
 
-			// If we're updating (which includes removing) throttles and the
-			// active count (those not marked for removal) is > 0, we should
-			// set the knownThrottles to true.
+			// If we're updating throttles and the active count (those not marked for
+			// removal) is > 0, we should set the knownThrottles to true.
 			if len(activeOverrideBrokers) > 0 {
 				knownThrottles = true
 			}

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -308,15 +308,12 @@ func main() {
 		// Apply any additional broker-specific throttles that were not applied as
 		// part of a reassignment.
 		if len(throttleMeta.brokerOverrides) > 0 {
-			// Find under-replicated topics that include brokers with static
-			// overrides that aren't being reassigned. In order for broker-specific
+			// Find all topics that include brokers with static overrides
+			// configured that aren't being reassigned. In order for broker-specific
 			// throttles to be applied, topics being replicated by those brokers
 			// must include them in the follower.replication.throttled.replicas
 			// dynamic configuration parameter. It's clumsy, but this is the way
 			// Kafka was designed.
-
-			// Get a topicThrottledReplicas for all topics that have partition
-			// assignments to any brokers with overrides.
 			// TODO(jamie): is there a scenario where we should exclude topics
 			// have also have a reassignment? We're discovering topics here by
 			// reverse lookup of brokers that are not reassignment participants.

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -337,7 +337,7 @@ func main() {
 		}
 
 		if !topicsReassigning && throttlesToClear && brokerOverridesSet {
-			log.Println("One or more broker level override are set; automatic throttle removal will be skipped")
+			log.Println("One or more brokers level override are set; automatic throttle removal will be skipped")
 		}
 
 		// If there's previously set throttles but no topics reassigning nor

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -306,6 +306,25 @@ func main() {
 		// Apply any additional broker-specific throttles that were not applied as
 		// part of a reassignment.
 		if len(throttleMeta.brokerOverrides) > 0 {
+			// Find under-replicated topics that include brokers with static
+			// overrides that aren't being reassigned. In order for broker-specific
+			// throttles to be applied, topics being replicated by those brokers
+			// must include them in the follower.replication.throttled.replicas
+			// dynamic configuration parameter. It's clumsy, but this is the way
+			// Kafka was designed.
+
+			// Get non-reassigning brokers with throttles
+			// Get topics by brokers
+			recovering, err := getRecoveringTopics(throttleMeta)
+			if err != nil {
+				log.Println(err)
+			}
+
+			_ = recovering
+
+			// Generate throttled replica configurations
+			// Pass to updateOverrideThrottles
+
 			if err := updateOverrideThrottles(throttleMeta); err != nil {
 				log.Println(err)
 			}

--- a/cmd/autothrottle/set.go
+++ b/cmd/autothrottle/set.go
@@ -49,3 +49,12 @@ func (s set) isSubSet(s2 set) bool {
 	}
 	return true
 }
+
+func (s set) equal(s2 set) bool {
+	for k := range s {
+		if _, exist := s2[k]; !exist {
+			return false
+		}
+	}
+	return len(s) == len(s2)
+}

--- a/cmd/autothrottle/set.go
+++ b/cmd/autothrottle/set.go
@@ -1,0 +1,51 @@
+package main
+
+type set map[string]struct{}
+
+func newSet() set {
+	return make(set)
+}
+
+func (s set) has(k string) bool {
+	_, has := s[k]
+	return has
+}
+
+func (s set) add(k string) {
+	s[k] = struct{}{}
+}
+
+func (s set) copy() set {
+	c := newSet()
+	for k := range s {
+		c.add(k)
+	}
+	return c
+}
+
+func (s set) keys() []string {
+	var ks []string
+	for k := range s {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+func (s set) diff(s2 set) set {
+	d := newSet()
+	for k := range s {
+		if !s2.has(k) {
+			d.add(k)
+		}
+	}
+	return d
+}
+
+func (s set) isSubSet(s2 set) bool {
+	for k := range s {
+		if !s2.has(k) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/autothrottle/set_test.go
+++ b/cmd/autothrottle/set_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestAddHas(t *testing.T) {
+	s := newSet()
+	s.add("key")
+
+	if !s.has("key") {
+		t.Error("Expected set to have key 'key'")
+	}
+
+	if s.has("nil") {
+		t.Error("Unexpected key in set")
+	}
+}
+
+func TestCopy(t *testing.T) {
+	s := newSet()
+	s.add("key")
+
+	s2 := s.copy()
+
+	if !s2.has("key") {
+		t.Error("Expected set to have key 'key'")
+	}
+}
+
+func TestKeys(t *testing.T) {
+	expected := []string{"key1", "key2", "key3"}
+
+	s := newSet()
+	for _, key := range expected {
+		s.add(key)
+	}
+
+	sort.Strings(expected)
+	got := s.keys()
+	sort.Strings(got)
+
+	if len(got) != len(expected) {
+		t.Fatalf("Expected keys len %d, got %d", len(expected), len(got))
+	}
+
+	for i, key := range expected {
+		if got[i] != key {
+			t.Errorf("Expected set to have key '%s'", key)
+		}
+	}
+}
+
+func TestDiff(t *testing.T) {
+	s1 := newSet()
+	s2 := newSet()
+
+	for _, key := range []string{"key1", "key2", "key3"} {
+		s1.add(key)
+		s2.add(key)
+	}
+
+	s2.add("key4")
+	diff := s2.diff(s1)
+
+	if len(diff) != 1 && !diff.has("key4") {
+		t.Errorf("Expected diff keys %v, got %v\n", []string{"key4"}, diff.keys())
+	}
+}
+
+func TestIsSubSet(t *testing.T) {
+	s1 := newSet()
+	s2 := newSet()
+
+	for _, key := range []string{"key1", "key2", "key3"} {
+		s1.add(key)
+		s2.add(key)
+	}
+
+	s2.add("key4")
+
+	if !s1.isSubSet(s2) {
+		t.Errorf("Expected %v to be subset of %v\n", s1.keys(), s2.keys())
+	}
+
+	if s2.isSubSet(s1) {
+		t.Errorf("Expected %v to not be subset of %v\n", s1.keys(), s2.keys())
+	}
+}

--- a/cmd/autothrottle/set_test.go
+++ b/cmd/autothrottle/set_test.go
@@ -88,3 +88,23 @@ func TestIsSubSet(t *testing.T) {
 		t.Errorf("Expected %v to not be subset of %v\n", s1.keys(), s2.keys())
 	}
 }
+
+func TestEqual(t *testing.T) {
+	s1 := newSet()
+	s2 := newSet()
+
+	for _, key := range []string{"key1", "key2", "key3"} {
+		s1.add(key)
+		s2.add(key)
+	}
+
+	if !s1.equal(s2) {
+		t.Error("Expected set equality")
+	}
+
+	s2.add("key4")
+
+	if s1.equal(s2) {
+		t.Error("Expected set inequality")
+	}
+}

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -8,12 +8,14 @@ import (
 // ReplicationThrottleConfigs holds all the data needed to call
 // updateReplicationThrottle.
 type ReplicationThrottleConfigs struct {
-	topics                 []string // TODO(jamie): probably don't even need this anymore.
-	reassignments          kafkazk.Reassignments
-	zk                     kafkazk.Handler
-	km                     kafkametrics.Handler
-	overrideRate           int
+	reassignments kafkazk.Reassignments
+	zk            kafkazk.Handler
+	km            kafkametrics.Handler
+	overrideRate  int
+	// The following two fields are for brokers with static overrides set
+	// and a topicThrottledReplicas for topics where those brokers are assigned.
 	brokerOverrides        BrokerOverrides
+	overrideThrottleLists  topicThrottledReplicas
 	reassigningBrokers     reassigningBrokers
 	events                 *DDEventWriter
 	previouslySetThrottles replicationCapacityByBroker

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -79,6 +79,10 @@ func hasActiveOverride(bto BrokerThrottleOverride) bool {
 	return bto.Config.Rate != 0
 }
 
+func notReassignmentParticipant(bto BrokerThrottleOverride) bool {
+	return !bto.ReassignmentParticipant && bto.Config.Rate != 0
+}
+
 // Filter takes a BrokerOverridesFilterFn and returns a BrokerOverrides where
 // all elements return true as an input to the filter func.
 func (b BrokerOverrides) Filter(fn BrokerOverridesFilterFn) BrokerOverrides {

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -45,6 +45,18 @@ type BrokerThrottleOverride struct {
 	Config ThrottleOverrideConfig
 }
 
+// Copy returns a copy of a BrokerThrottleOverride.
+func (b BrokerThrottleOverride) Copy() BrokerThrottleOverride {
+	return BrokerThrottleOverride{
+		ID:                      b.ID,
+		ReassignmentParticipant: b.ReassignmentParticipant,
+		Config: ThrottleOverrideConfig{
+			Rate:       b.Config.Rate,
+			AutoRemove: b.Config.AutoRemove,
+		},
+	}
+}
+
 // IDs returns a []int of broker IDs held by the BrokerOverrides.
 func (b BrokerOverrides) IDs() []int {
 	var ids []int
@@ -53,6 +65,22 @@ func (b BrokerOverrides) IDs() []int {
 	}
 
 	return ids
+}
+
+// BrokerOverridesFilterFn specifies a filter function.
+type BrokerOverridesFilterFn func(BrokerThrottleOverride) bool
+
+// Filter takes a BrokerOverridesFilterFn and returns a BrokerOverrides where
+// all elements return true as an input to the filter func.
+func (b BrokerOverrides) Filter(fn BrokerOverridesFilterFn) BrokerOverrides {
+	var bo = make(BrokerOverrides)
+	for _, bto := range b {
+		if fn(bto) {
+			bo[bto.ID] = bto.Copy()
+		}
+	}
+
+	return bo
 }
 
 // Failure increments the failures count and returns true if the

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -12,17 +12,18 @@ type ReplicationThrottleConfigs struct {
 	zk            kafkazk.Handler
 	km            kafkametrics.Handler
 	overrideRate  int
-	// The following two fields are for brokers with static overrides set
+	// The following three fields are for brokers with static overrides set
 	// and a topicThrottledReplicas for topics where those brokers are assigned.
-	brokerOverrides        BrokerOverrides
-	overrideThrottleLists  topicThrottledReplicas
-	reassigningBrokers     reassigningBrokers
-	events                 *DDEventWriter
-	previouslySetThrottles replicationCapacityByBroker
-	limits                 Limits
-	failureThreshold       int
-	failures               int
-	skipTopicUpdates       bool
+	brokerOverrides          BrokerOverrides
+	overrideThrottleLists    topicThrottledReplicas
+	skipOverrideTopicUpdates bool
+	reassigningBrokers       reassigningBrokers
+	events                   *DDEventWriter
+	previouslySetThrottles   replicationCapacityByBroker
+	limits                   Limits
+	failureThreshold         int
+	failures                 int
+	skipTopicUpdates         bool
 }
 
 // ThrottleOverrideConfig holds throttle override configurations.
@@ -114,10 +115,21 @@ func (r *ReplicationThrottleConfigs) DisableTopicUpdates() {
 	r.skipTopicUpdates = true
 }
 
-// DisableTopicUpdates allow topic throttled replica lists from being
-// updated in ZooKeeper.
+// DisableTopicUpdates allows topic throttled replica lists updates in ZooKeeper.
 func (r *ReplicationThrottleConfigs) EnableTopicUpdates() {
 	r.skipTopicUpdates = false
+}
+
+// DisableOverrideTopicUpdates prevents topic throttled replica lists for
+// topics assigned to override brokers from being updated in ZooKeeper.
+func (r *ReplicationThrottleConfigs) DisableOverrideTopicUpdates() {
+	r.skipOverrideTopicUpdates = true
+}
+
+// EnableOverrideTopicUpdates allows topic throttled replica lists for
+// topics assigned to override brokers to be updated in ZooKeeper.
+func (r *ReplicationThrottleConfigs) EnableOverrideTopicUpdates() {
+	r.skipOverrideTopicUpdates = false
 }
 
 // ThrottledBrokers is a list of brokers with a throttle applied

--- a/cmd/autothrottle/throttles.go
+++ b/cmd/autothrottle/throttles.go
@@ -72,6 +72,12 @@ func (b BrokerOverrides) IDs() []int {
 // BrokerOverridesFilterFn specifies a filter function.
 type BrokerOverridesFilterFn func(BrokerThrottleOverride) bool
 
+// Filter funcs.
+
+func hasActiveOverride(bto BrokerThrottleOverride) bool {
+	return bto.Config.Rate != 0
+}
+
 // Filter takes a BrokerOverridesFilterFn and returns a BrokerOverrides where
 // all elements return true as an input to the filter func.
 func (b BrokerOverrides) Filter(fn BrokerOverridesFilterFn) BrokerOverrides {

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -204,6 +204,12 @@ func updateOverrideThrottles(params *ReplicationThrottleConfigs) error {
 		log.Println(e)
 	}
 
+	// Set topic throttle configs.
+	_, errs = applyTopicThrottles(params.overrideThrottleLists, params.zk)
+	for _, e := range errs {
+		log.Println(e)
+	}
+
 	// Append broker throttle info to event.
 	var b bytes.Buffer
 	if len(events) > 0 {

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -155,7 +155,11 @@ func updateReplicationThrottle(params *ReplicationThrottleConfigs) error {
 	}
 
 	// Append topic stats to event.
-	b.WriteString(fmt.Sprintf("Topics currently undergoing replication: %v", params.topics))
+	var topics []string
+	for t := range params.reassignments {
+		topics = append(topics, t)
+	}
+	b.WriteString(fmt.Sprintf("Topics currently undergoing replication: %v", topics))
 
 	// Ship it.
 	params.events.Write("Broker replication throttle set", b.String())

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -134,14 +134,6 @@ func updateReplicationThrottle(params *ReplicationThrottleConfigs) error {
 		log.Println(e)
 	}
 
-	// Set topic throttle configs.
-	if !params.skipTopicUpdates {
-		_, errs = applyTopicThrottles(params.reassigningBrokers.throttledReplicas, params.zk)
-		for _, e := range errs {
-			log.Println(e)
-		}
-	}
-
 	// Append broker throttle info to event.
 	var b bytes.Buffer
 	if len(events) > 0 {
@@ -152,6 +144,14 @@ func updateReplicationThrottle(params *ReplicationThrottleConfigs) error {
 		}
 
 		b.WriteString("\n")
+	}
+
+	// Set topic throttle configs.
+	if !params.skipTopicUpdates {
+		_, errs = applyTopicThrottles(params.reassigningBrokers.throttledReplicas, params.zk)
+		for _, e := range errs {
+			log.Println(e)
+		}
 	}
 
 	// Append topic stats to event.

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -115,6 +115,7 @@ func updateReplicationThrottle(params *ReplicationThrottleConfigs) error {
 			// Any brokers with throttle overrides that are being issued as part
 			// of a reassignemnt should be marked as such.
 			override.ReassignmentParticipant = true
+			params.brokerOverrides[id] = override
 
 			rate := override.Config.Rate
 			// A rate of 0 means we intend to remove this throttle override. Skip.

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -112,16 +112,17 @@ func updateReplicationThrottle(params *ReplicationThrottleConfigs) error {
 	// Merge in broker-specific overrides if they're part of the reassignment.
 	for id := range params.reassigningBrokers.all {
 		if override, exists := params.brokerOverrides[id]; exists {
+			// Any brokers with throttle overrides that are being issued as part
+			// of a reassignemnt should be marked as such.
+			override.ReassignmentParticipant = true
+
 			rate := override.Config.Rate
 			// A rate of 0 means we intend to remove this throttle override. Skip.
 			if rate == 0 {
 				continue
 			}
+
 			log.Printf("A broker throttle override is set for %d: %dMB/s\n", id, rate)
-			// Any brokers with throttle overrides that are being issued as part
-			// of a reassignemnt should be marked as such.
-			override.ReassignmentParticipant = true
-			params.brokerOverrides[id] = override
 			// Store the rate for both inbound and outbound traffic.
 			capacities.storeLeaderAndFollerCapacity(id, float64(rate))
 		}

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -193,7 +193,7 @@ func updateOverrideThrottles(params *ReplicationThrottleConfigs) error {
 	}
 
 	if len(toAssign) > 0 || len(toRemove) > 0 {
-		log.Println("Updating additional throttles")
+		log.Println("Setting broker level throttle overrides")
 	} else {
 		return nil
 	}
@@ -223,7 +223,7 @@ func updateOverrideThrottles(params *ReplicationThrottleConfigs) error {
 	}
 
 	// Ship it.
-	params.events.Write("Additional broker replication throttle set", b.String())
+	params.events.Write("Broker level throttle override(s) configured", b.String())
 
 	// Unset the broker throttles marked for removal.
 	return removeBrokerThrottlesByID(params, toRemove)

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -377,6 +378,11 @@ func applyTopicThrottles(throttled topicThrottledReplicas, zk kafkazk.Handler) (
 			Name:    string(t),
 			Configs: []kafkazk.KafkaConfigKV{},
 		}
+
+		// The sort is important; it avoids unecessary config updates due to the same
+		// data but in different orders.
+		sort.Strings(throttled[t]["leaders"])
+		sort.Strings(throttled[t]["followers"])
 
 		leaderList := strings.Join(throttled[t]["leaders"], ",")
 		if leaderList != "" {

--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -207,9 +207,11 @@ func updateOverrideThrottles(params *ReplicationThrottleConfigs) error {
 	}
 
 	// Set topic throttle configs.
-	_, errs = applyTopicThrottles(params.overrideThrottleLists, params.zk)
-	for _, e := range errs {
-		log.Println(e)
+	if !params.skipOverrideTopicUpdates {
+		_, errs = applyTopicThrottles(params.overrideThrottleLists, params.zk)
+		for _, e := range errs {
+			log.Println(e)
+		}
 	}
 
 	// Append broker throttle info to event.

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+)
+
+// topicThrottledReplicas is a map of topic names to throttled types.
+// This is ultimately populated as follows:
+//   map[topic]map[leaders]["0:1001", "1:1002"]
+//   map[topic]map[followers]["2:1003", "3:1004"]
+type topicThrottledReplicas map[topic]throttled
+
+// throttled is a replica type (leader, follower) to replica list.
+type throttled map[replicaType]brokerIDs
+
+// topic name.
+type topic string
+
+// leader, follower.
+type replicaType string
+
+// Replica broker IDs as a []string.
+type brokerIDs []string
+
+// topicStates is a map of topic names to kafakzk.TopicState.
+type topicStates map[string]kafkazk.TopicState
+
+// getRecoveringTopics
+func getRecoveringTopics(params *ReplicationThrottleConfigs) (topicStates, error) {
+	return getAllTopicStates(params.zk)
+}
+
+func getAllTopicStates(zk kafkazk.Handler) (topicStates, error) {
+	var states = make(topicStates)
+
+	// Get all topics.
+	topics, err := zk.GetTopics(topicsRegex)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch state for each topic.
+	for _, topic := range topics {
+		state, err := zk.GetTopicState(topic)
+		if err != nil {
+			return nil, err
+		}
+		states[topic] = *state
+	}
+
+	return states, nil
+}

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
 
@@ -12,6 +15,35 @@ type topicThrottledReplicas map[topic]throttled
 
 // throttled is a replica type (leader, follower) to replica list.
 type throttled map[replicaType]brokerIDs
+
+// AddReplica takes a topic, partition number, role (leader, follower), and
+// broker ID and adds the configuration to the topicThrottledReplicas.
+func (ttr topicThrottledReplicas) AddReplica(topic topic, partn string, role replicaType, id string) {
+	// Check / create the topic entry.
+	if _, exist := ttr[topic]; !exist {
+		ttr[topic] = make(throttled)
+	}
+
+	// Check / create the leader/follower list.
+	if ttr[topic][role] == nil {
+		ttr[topic][role] = []string{}
+	}
+
+	// Form the throttled replica string.
+	str := fmt.Sprintf("%s:%s", partn, id)
+
+	// If the entry is already in the list, return early.
+	for _, entry := range ttr[topic][role] {
+		if entry == str {
+			return
+		}
+	}
+
+	// Otherwise add the entry.
+	l := ttr[topic][role]
+	l = append(l, str)
+	ttr[topic][role] = l
+}
 
 // topic name.
 type topic string
@@ -41,9 +73,10 @@ func (t TopicStates) Filter(fn TopicStatesFilterFn) TopicStates {
 	return ts
 }
 
-// getTopicsWithThrottledBrokers returns a TopicStates that includes any topics that
-// have partitions assigned to brokers with a static throttle rate set.
-func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (TopicStates, error) {
+// getTopicsWithThrottledBrokers returns a topicThrottledReplicas that includes
+// any topics that have partitions assigned to brokers with a static throttle
+// rate set.
+func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThrottledReplicas, error) {
 	// Fetch all topic states.
 	states, err := getAllTopicStates(params.zk)
 	if err != nil {
@@ -51,15 +84,15 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (TopicSta
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
-	overridesFilterFn := func(bto BrokerThrottleOverride) bool {
+	notReassignmentParticipant := func(bto BrokerThrottleOverride) bool {
 		return !bto.ReassignmentParticipant
 	}
 
-	overrides := params.brokerOverrides.Filter(overridesFilterFn)
+	throttledBrokers := params.brokerOverrides.Filter(notReassignmentParticipant)
 
-	// Filter out topic states where the target brokers are assigned to at least
-	// one partition.
-	statesFilterFn := func(ts kafkazk.TopicState) bool {
+	Filter out topic states where the target brokers are assigned to at least
+	one partition.
+	assignedToBroker := func(ts kafkazk.TopicState) bool {
 		for _, assignment := range ts.Partitions {
 			for _, id := range assignment {
 				if _, exists := overrides[id]; exists {
@@ -70,7 +103,33 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (TopicSta
 		return false
 	}
 
-	return states.Filter(statesFilterFn), nil
+	return states.Filter(assignedToID), nil
+
+	// // Construct a topicThrottledReplicas that includes any topics with replicas
+	// // assigned to brokers with overrides. The throttled list only includes brokers
+	// // with throttles set rather than all configured replicas.
+	// var throttleLists = make(topicThrottledReplicas)
+	//
+	// // For each topic...
+	// for topicName, state := range states {
+	// 	// For each partition...
+	// 	for partn, replicas := range state.Partitions {
+	// 		// For each replica assignment...
+	// 		for _, assignedID := range replicas {
+	// 			// If the replica is a throttled broker, append that broker to the
+	// 			// throttled list for this {topic, partition}.
+	// 			if _, exists := throttledBrokers[assignedID]; exists {
+	// 				throttleLists.AddReplica(
+	// 					topic(topicName),
+	// 					partn,
+	// 					replicaType("follower"),
+	// 					strconv.Itoa(assignedID))
+	// 			}
+	// 		}
+	// 	}
+	// }
+	//
+	// return throttleLists, nil
 }
 
 // getAllTopicStates returns a TopicStates for all topics in Kafka.

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -16,9 +16,9 @@ type topicThrottledReplicas map[topic]throttled
 // throttled is a replica type (leader, follower) to replica list.
 type throttled map[replicaType]brokerIDs
 
-// AddReplica takes a topic, partition number, role (leader, follower), and
+// addReplica takes a topic, partition number, role (leader, follower), and
 // broker ID and adds the configuration to the topicThrottledReplicas.
-func (ttr topicThrottledReplicas) AddReplica(topic topic, partn string, role replicaType, id string) {
+func (ttr topicThrottledReplicas) addReplica(topic topic, partn string, role replicaType, id string) {
 	// Check / create the topic entry.
 	if _, exist := ttr[topic]; !exist {
 		ttr[topic] = make(throttled)
@@ -104,7 +104,7 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 				// If the replica is a throttled broker, append that broker to the
 				// throttled list for this {topic, partition}.
 				if _, exists := throttledBrokers[assignedID]; exists {
-					throttleLists.AddReplica(
+					throttleLists.addReplica(
 						topic(topicName),
 						partn,
 						replicaType("follower"),

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -97,7 +97,10 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 
 	// For each topic...
 	for topicName, state := range states {
-		// TODO(jamie): skip consumer offsets
+		// TODO(jamie): make this configurable.
+		if topicName == "__consumer_offsets" {
+			continue
+		}
 		// For each partition...
 		for partn, replicas := range state.Partitions {
 			// For each replica assignment...

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -21,6 +21,15 @@ type topicThrottledReplicas map[topic]throttled
 // throttled is a replica type (leader, follower) to replica list.
 type throttled map[replicaType]brokerIDs
 
+// topic name.
+type topic string
+
+// leader, follower.
+type replicaType string
+
+// Replica broker IDs as a []string where string == partition_number:broker_id.
+type brokerIDs []string
+
 var acceptedReplicaTypes = map[replicaType]struct{}{
 	"leaders":   struct{}{},
 	"followers": struct{}{},
@@ -60,15 +69,6 @@ func (ttr topicThrottledReplicas) addReplica(topic topic, partn string, role rep
 
 	return nil
 }
-
-// topic name.
-type topic string
-
-// leader, follower.
-type replicaType string
-
-// Replica broker IDs as a []string.
-type brokerIDs []string
 
 // TopicStates is a map of topic names to kafakzk.TopicState.
 type TopicStates map[string]kafkazk.TopicState

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -100,10 +100,6 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
-	notReassignmentParticipant := func(bto BrokerThrottleOverride) bool {
-		return !bto.ReassignmentParticipant && bto.Config.Rate != 0
-	}
-
 	throttledBrokers := params.brokerOverrides.Filter(notReassignmentParticipant)
 
 	// Construct a topicThrottledReplicas that includes any topics with replicas

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -84,9 +84,8 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
-	// TODO(jamie): skip brokers where the throttle is 0.
 	notReassignmentParticipant := func(bto BrokerThrottleOverride) bool {
-		return !bto.ReassignmentParticipant
+		return !bto.ReassignmentParticipant && bto.Config.Rate != 0
 	}
 
 	throttledBrokers := params.brokerOverrides.Filter(notReassignmentParticipant)

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -84,6 +84,7 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
+	// TODO(jamie): skip brokers where the throttle is 0.
 	notReassignmentParticipant := func(bto BrokerThrottleOverride) bool {
 		return !bto.ReassignmentParticipant
 	}
@@ -97,6 +98,7 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 
 	// For each topic...
 	for topicName, state := range states {
+		// TODO(jamie): skip consumer offsets
 		// For each partition...
 		for partn, replicas := range state.Partitions {
 			// For each replica assignment...
@@ -107,7 +109,7 @@ func getTopicsWithThrottledBrokers(params *ReplicationThrottleConfigs) (topicThr
 					throttleLists.addReplica(
 						topic(topicName),
 						partn,
-						replicaType("follower"),
+						replicaType("followers"),
 						strconv.Itoa(assignedID))
 				}
 			}

--- a/cmd/autothrottle/topics.go
+++ b/cmd/autothrottle/topics.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
-	"errors"
 
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
 )
@@ -22,7 +22,7 @@ type topicThrottledReplicas map[topic]throttled
 type throttled map[replicaType]brokerIDs
 
 var acceptedReplicaTypes = map[replicaType]struct{}{
-	"leaders": struct{}{},
+	"leaders":   struct{}{},
 	"followers": struct{}{},
 }
 

--- a/cmd/autothrottle/topics_test.go
+++ b/cmd/autothrottle/topics_test.go
@@ -9,6 +9,7 @@ import (
 func TestAddReplica(t *testing.T) {
 	ttr := make(topicThrottledReplicas)
 
+	// Try to add an invalid type.
 	err := ttr.addReplica("test", "0", "invalid", "1001")
 	if err != errInvalidReplicaType {
 		t.Errorf("Expected 'errInvalidReplicaType' error")
@@ -16,6 +17,7 @@ func TestAddReplica(t *testing.T) {
 
 	types := []replicaType{"leaders", "followers"}
 
+	// Add valid types; error unexpected.
 	for _, typ := range types {
 		err := ttr.addReplica("test", "0", replicaType(typ), "1001")
 		if err != nil {
@@ -23,6 +25,7 @@ func TestAddReplica(t *testing.T) {
 		}
 	}
 
+	// For each type {leaders, followers}, ensure that we have one follower entry.
 	for _, typ := range types {
 		gotLen := len(ttr["test"][typ])
 		if gotLen != 1 {
@@ -30,6 +33,7 @@ func TestAddReplica(t *testing.T) {
 		}
 	}
 
+	// Spot check the content.
 	if ttr["test"]["leaders"][0] != "0:1001" {
 		t.Errorf("Expected output '0:1001', got '%s'", ttr["test"]["leaders"][0])
 	}
@@ -43,6 +47,8 @@ func TestFilter(t *testing.T) {
 	topicStates["test_topic"] = *state
 
 	matchID := 1000
+
+	// Our filter func. returns any topic that includes matchID as a replica.
 	fn := func(ts kafkazk.TopicState) bool {
 		// The mock partition state here is []int{1000,1001}.
 		for _, id := range ts.Partitions["0"] {
@@ -53,6 +59,7 @@ func TestFilter(t *testing.T) {
 		return false
 	}
 
+	// We should get back one topic.
 	filtered := topicStates.Filter(fn)
 	_, match := filtered["test_topic"]
 	if len(filtered) != 1 && !match {
@@ -60,33 +67,63 @@ func TestFilter(t *testing.T) {
 	}
 
 	matchID = 9999
+
+	// We should now have no matched topics.
 	filtered = topicStates.Filter(fn)
 	if len(filtered) != 0 {
 		t.Errorf("Expected nil filtered result")
 	}
 }
 
-// func TestGetTopicsWithThrottledBrokers(t *testing.T) {
-// 	rtf := &ReplicationThrottleConfigs{
-// 		zk: &kafkazk.Mock{},
-// 	}
-//
-// 	rtf.brokerOverrides = BrokerOverrides{
-// 		1001: BrokerThrottleOverride{
-// 			ID: 1001,
-// 			ReassignmentParticipant: false,
-// 			Config: ThrottleOverrideConfig{
-// 				Rate: 50,
-// 			},
-// 		},
-// 		1002: BrokerThrottleOverride{
-// 			ID: 1002,
-// 			ReassignmentParticipant: false,
-// 			Config: ThrottleOverrideConfig{
-// 				Rate: 50,
-// 			},
-// 		},
-// 	}
-//
-// 	fmt.Println(getTopicsWithThrottledBrokers(rtf))
-// }
+func TestGetTopicsWithThrottledBrokers(t *testing.T) {
+	rtf := &ReplicationThrottleConfigs{
+		zk: &kafkazk.Mock{},
+	}
+
+	// Minimally populate the ReplicationThrottleConfigs.
+	rtf.brokerOverrides = BrokerOverrides{
+		1001: BrokerThrottleOverride{
+			ID:                      1001,
+			ReassignmentParticipant: false,
+			Config: ThrottleOverrideConfig{
+				Rate: 50,
+			},
+		},
+		// Topics that include this broker shouldn't be included; the
+		// BrokerThrottleOverride.Filter called in getTopicsWithThrottledBrokers
+		// excludes any topics mapped to brokers where ReassignmentParticipant
+		// == true.
+		1002: BrokerThrottleOverride{
+			ID:                      1002,
+			ReassignmentParticipant: true,
+			Config: ThrottleOverrideConfig{
+				Rate: 50,
+			},
+		},
+	}
+
+	// Call.
+	topicThrottledBrokers, _ := getTopicsWithThrottledBrokers(rtf)
+
+	expected := topicThrottledReplicas{
+		"test_topic":  throttled{"followers": brokerIDs{"0:1001"}},
+		"test_topic2": throttled{"followers": brokerIDs{"0:1001"}},
+	}
+
+	if len(topicThrottledBrokers) != len(expected) {
+		t.Fatalf("Expected len %d, got %d", len(expected), len(topicThrottledBrokers))
+	}
+
+	for topic := range expected {
+		output, exist := topicThrottledBrokers[topic]
+		if !exist {
+			t.Fatalf("Expected topic '%s' in output", topic)
+		}
+
+		got := output["followers"][0]
+		expectedOut := expected[topic]["followers"][0]
+		if got != expectedOut {
+			t.Errorf("Expected followers '%s', got '%s'", expectedOut, got)
+		}
+	}
+}

--- a/cmd/autothrottle/topics_test.go
+++ b/cmd/autothrottle/topics_test.go
@@ -12,10 +12,23 @@ func TestAddReplica(t *testing.T) {
 		t.Errorf("Expected 'errInvalidReplicaType' error")
 	}
 
-	for _, typ := range []string{"leaders", "followers"} {
+	types := []replicaType{"leaders", "followers"}
+
+	for _, typ := range types {
 		err := ttr.addReplica("test", "0", replicaType(typ), "1001")
 		if err != nil {
 			t.Errorf("Unexpected error: %s", err)
 		}
+	}
+
+	for _, typ := range types {
+		gotLen := len(ttr["test"][typ])
+		if gotLen != 1 {
+			t.Errorf("Expected len 1 for ttr[test][%s], got %d", typ, gotLen)
+		}
+	}
+
+	if ttr["test"]["leaders"][0] != "0:1001" {
+		t.Errorf("Expected output '0:1001', got '%s'", ttr["test"]["leaders"][0])
 	}
 }

--- a/cmd/autothrottle/topics_test.go
+++ b/cmd/autothrottle/topics_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAddReplica(t *testing.T) {
+	ttr := make(topicThrottledReplicas)
+
+	err := ttr.addReplica("test", "0", "invalid", "1001")
+	if err != errInvalidReplicaType {
+		t.Errorf("Expected 'errInvalidReplicaType' error")
+	}
+
+	for _, typ := range []string{"leaders", "followers"} {
+		err := ttr.addReplica("test", "0", replicaType(typ), "1001")
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
# Problem
When applying a broker specific throttle rate, even for non-reassignment traffic, the throttle must also be propagated to the topic metadata. There's a lot of complexities here. See #313.

# Updates
- Brokers with static overrides that are part of a reassignment continue benefiting from individual throttles.
- Brokers with static overrides that are not part of a reassignment will have throttle metadata for any assigned partitions updated with the throttle.
- A reduction in Kafka cluster state update notifications via ZooKeeper.
- Additional tests.
- Minor code cleanup.

Closes #313.