### PR TITLE
improved metrics fetching reliability

### DIFF
--- a/cmd/metricsfetcher/metrics.go
+++ b/cmd/metricsfetcher/metrics.go
@@ -1,13 +1,25 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	dd "github.com/zorkian/go-datadog-api"
 )
 
+// Both fuctions here fetch 2x the span in duration to handle lagging
+// metrics from the DD API. This should result in a max of two rollup values
+// per timeseries. We then choose the latest non-nil value.
+
+// It's also OK to ignore errors beyond the metrics query. Sometimes one or more
+// timeseries may not have been returned, but if we're not using them, it doesn't
+// matter. Error handling for required but missing metrics is handled elsewhere
+// in metricsfetcher.
+
 func partitionMetrics(c *Config) (map[string]map[string]map[string]float64, error) {
-	start := time.Now().Add(-time.Duration(c.Span) * time.Second).Unix()
+	start := time.Now().Add(-time.Duration(c.Span*2) * time.Second).Unix()
 	o, err := c.Client.QueryMetrics(start, time.Now().Unix(), c.PartnQuery)
 	if err != nil {
 		return nil, err
@@ -17,27 +29,32 @@ func partitionMetrics(c *Config) (map[string]map[string]map[string]float64, erro
 
 	for _, ts := range o {
 		topic := tagValFromScope(ts.GetScope(), "topic")
-		// Cope with the double underscore
-		// dedupe in the __consumer_offsets topic.
+		// Cope with the double underscore dedupe in the __consumer_offsets topic.
 		if topic == "_consumer_offsets" {
 			topic = "__consumer_offsets"
 		}
 
 		partition := tagValFromScope(ts.GetScope(), "partition")
 
+		// Get the latest value.
+		val, err := latestValue(ts.Points)
+		if err != nil {
+			continue
+		}
+
 		if _, exists := d[topic]; !exists {
 			d[topic] = map[string]map[string]float64{}
 		}
 
 		d[topic][partition] = map[string]float64{}
-		d[topic][partition]["Size"] = *ts.Points[0][1]
+		d[topic][partition]["Size"] = val
 	}
 
 	return d, nil
 }
 
 func brokerMetrics(c *Config) (map[string]map[string]float64, error) {
-	start := time.Now().Add(-time.Duration(c.Span) * time.Second).Unix()
+	start := time.Now().Add(-time.Duration(c.Span*2) * time.Second).Unix()
 	o, err := c.Client.QueryMetrics(start, time.Now().Unix(), c.BrokerQuery)
 	if err != nil {
 		return nil, err
@@ -49,12 +66,15 @@ func brokerMetrics(c *Config) (map[string]map[string]float64, error) {
 	for _, ts := range o {
 		broker := tagValFromScope(ts.GetScope(), c.BrokerIDTag)
 
-		// Check that the tag value
-		// is actually a broker ID.
-		// An improperly tagged or
-		// untagged broker may have "N/A"
-		// or some other invalid value.
+		// Check that the tag value is actually a broker ID. An improperly tagged or
+		// untagged broker may have "N/A" or some other invalid value.
 		if _, err := strconv.Atoi(broker); err != nil {
+			continue
+		}
+
+		// Get the latest value.
+		val, err := latestValue(ts.Points)
+		if err != nil {
 			continue
 		}
 
@@ -62,22 +82,31 @@ func brokerMetrics(c *Config) (map[string]map[string]float64, error) {
 			d[broker] = map[string]float64{}
 		}
 
-		d[broker]["StorageFree"] = *ts.Points[0][1]
+		d[broker]["StorageFree"] = val
 	}
 
 	return d, nil
 }
 
-// tagValFromScope takes a metric scope string
-// and a tag and returns that tag's value.
+func latestValue(points []dd.DataPoint) (float64, error) {
+	for i := len(points) - 1; i >= 0; i-- {
+		val := points[i][1]
+		if val != nil {
+			return *val, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no value found")
+}
+
+// tagValFromScope takes a metric scope string and a tag and returns that tag's value.
 func tagValFromScope(scope, tag string) string {
 	ts := strings.Split(scope, ",")
 
 	return valFromTags(ts, tag)
 }
 
-// valFromTags takes a []string of tags and
-// a key, returning the value for the key.
+// valFromTags takes a []string of tags and a key, returning the value for the key.
 func valFromTags(tags []string, key string) string {
 	var v []string
 

--- a/cmd/metricsfetcher/metrics.go
+++ b/cmd/metricsfetcher/metrics.go
@@ -88,6 +88,8 @@ func brokerMetrics(c *Config) (map[string]map[string]float64, error) {
 	return d, nil
 }
 
+// latestValue takes a []dd.DataPoint and returns the most recent (in time)
+// non-nil datapoint.
 func latestValue(points []dd.DataPoint) (float64, error) {
 	for i := len(points) - 1; i >= 0; i-- {
 		val := points[i][1]

--- a/cmd/metricsfetcher/metrics.go
+++ b/cmd/metricsfetcher/metrics.go
@@ -9,7 +9,7 @@ import (
 	dd "github.com/zorkian/go-datadog-api"
 )
 
-// Both fuctions here fetch 2x the span in duration to handle lagging
+// Both functions here fetch 2x the span in duration to handle lagging
 // metrics from the DD API. This should result in a max of two rollup values
 // per timeseries. We then choose the latest non-nil value.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/kafka-kit/v3
 go 1.13
 
 require (
+	github.com/DataDog/kafka-kit v3.1.0+incompatible // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/confluentinc/confluent-kafka-go v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/kafka-kit v3.1.0+incompatible h1:e1WS4yvyZWAzPUEghC/B1+luxH8HW4XrMlCg9oCUtm8=
+github.com/DataDog/kafka-kit v3.1.0+incompatible/go.mod h1:RW7sdzaLDyhgBIB2/QNvlGElazuSyeYLU5oUL0N077U=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Metricsfetcher takes a `--span` parameter that defaults to 1 hour. When fetching broker storage and partition size metrics data, it request a time range of `now()-span` and does an average rollup of `span`. Ideally, this results in a single average value for the last `span` (1h unless specified) time range.

When Datadog is experiencing lag or aggregation issues, we may get a nil result. This change increases the query time range to `2 * span`, resulting in 2 rollup data points. We then select the latest non-nil value, if available, increasing our resilience against metrics backend problems.