### PR TITLE
Jamie/exclude topics

### DIFF
--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -53,27 +53,28 @@ func bootstrap(cmd *cobra.Command) {
 }
 
 // topicRegex takes a string of csv values and returns a []*regexp.Regexp.
-// The values are either literal and become ^value$ or are regex and compiled
-// and added as-is.
+// The values are either a string literal and become ^value$ or are regex and
+// compiled then added.
 func topicRegex(s string) []*regexp.Regexp {
 	var out []*regexp.Regexp
-	// Check values.
+
+	// Update string literals to ^value$ regex.
 	topicNames := strings.Split(s, ",")
 	for n, t := range topicNames {
 		if !containsRegex(t) {
 			topicNames[n] = fmt.Sprintf(`^%s$`, t)
 		}
+	}
 
-		// Compile topic regex.
-		for _, t := range topicNames {
-			r, err := regexp.Compile(t)
-			if err != nil {
-				fmt.Printf("Invalid topic regex: %s\n", t)
-				os.Exit(1)
-			}
-
-			out = append(out, r)
+	// Compile regex patterns.
+	for _, t := range topicNames {
+		r, err := regexp.Compile(t)
+		if err != nil {
+			fmt.Printf("Invalid topic regex: %s\n", t)
+			os.Exit(1)
 		}
+
+		out = append(out, r)
 	}
 
 	return out

--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -12,7 +12,7 @@ import (
 )
 
 // checkMetaAge checks the age of the stored partition and broker storage
-// metrics data against the tolarated metrics age parameter.
+// metrics data against the tolerated metrics age parameter.
 func checkMetaAge(cmd *cobra.Command, zk kafkazk.Handler) {
 	age, err := zk.MaxMetaAge()
 	if err != nil {

--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"fmt"
 	"os"
-	"time"
 	"regexp"
+	"time"
 
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
 

--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -116,15 +116,18 @@ func removeTopics(pm *kafkazk.PartitionMap, r []*regexp.Regexp) []string {
 
 	// Traverse the partition map.
 	for _, p := range pm.Partitions {
-		for _, re := range r {
+		for i, re := range r {
 			// If the topic matches any regex pattern, add it to the removed set.
 			if re.MatchString(p.Topic) {
 				removed[p.Topic] = struct{}{}
 				break
 			}
 
-			// Else, it wasn't marked for removal; add it to the new PartitionList.
-			newPL = append(newPL, p)
+			// We've checked all patterns.
+			if i == len(r)-1 {
+				// Else, it wasn't marked for removal; add it to the new PartitionList.
+				newPL = append(newPL, p)
+			}
 		}
 	}
 

--- a/cmd/topicmappr/commands/metadata_test.go
+++ b/cmd/topicmappr/commands/metadata_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+)
+
+func TestRemoveTopics(t *testing.T) {
+	zk := kafkazk.NewZooKeeperMock()
+	pm1, _ := zk.GetPartitionMap("test")
+	pm2, _ := zk.GetPartitionMap("test2")
+	pm3, _ := zk.GetPartitionMap("test3")
+
+	pm := mergePartitionMaps(pm1, pm2, pm3)
+
+	// Remove all topics with a trailing digit.
+	re := regexp.MustCompile(`\d$`)
+	toRemove := []*regexp.Regexp{re}
+
+	removed := removeTopics(pm, toRemove)
+
+	// Check the removed output.
+	if len(removed) != 2 {
+		t.Fatalf("Expected removed length of 2 got %d", len(removed))
+	}
+
+	sort.Strings(removed)
+	expectedRemove := []string{"test2", "test3"}
+	for i, r := range removed {
+		if r != expectedRemove[i] {
+			t.Errorf("Expected removed topic '%s', got '%s'", expectedRemove[i], r)
+		}
+	}
+
+	// Test remaining in PartitionMap.
+	topics := pm.Topics()
+
+	if len(topics) != 1 {
+		t.Fatalf("Expected remaining topics length of 1, got %d", len(topics))
+	}
+
+	if topics[0] != "test" {
+		t.Fatalf("Expected remaining topic 'test', got '%s'", topics[0])
+	}
+}
+
+func mergePartitionMaps(pms ...*kafkazk.PartitionMap) *kafkazk.PartitionMap {
+	pm := kafkazk.NewPartitionMap()
+
+	for _, p := range pms {
+		pm.Partitions = append(pm.Partitions, p.Partitions...)
+	}
+
+	return pm
+}

--- a/cmd/topicmappr/commands/metadata_test.go
+++ b/cmd/topicmappr/commands/metadata_test.go
@@ -17,8 +17,12 @@ func TestRemoveTopics(t *testing.T) {
 	pm := mergePartitionMaps(pm1, pm2, pm3)
 
 	// Remove all topics with a trailing digit.
-	re := regexp.MustCompile(`\d$`)
-	toRemove := []*regexp.Regexp{re}
+	toRemove := []*regexp.Regexp{
+		// Junk pattern.
+		regexp.MustCompile(`asdf`),
+		// Pattern we care about.
+		regexp.MustCompile(`\d$`),
+	}
 
 	removed := removeTopics(pm, toRemove)
 

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -18,8 +18,8 @@ func (e errors) Len() int           { return len(e) }
 func (e errors) Less(i, j int) bool { return e[i].Error() < e[j].Error() }
 func (e errors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
 
-// printTopics takes a partition map and prints out
-// the names of all topics referenced in the map.
+// printTopics takes a partition map and prints out the names of all topics
+// referenced in the map.
 func printTopics(pm *kafkazk.PartitionMap) {
 	topics := map[string]struct{}{}
 	for _, p := range pm.Partitions {
@@ -32,20 +32,26 @@ func printTopics(pm *kafkazk.PartitionMap) {
 	}
 }
 
-func printExcludedTopics(p []string) {
+func printExcludedTopics(p []string, e []string) {
 	if len(p) > 0 {
 		fmt.Printf("\nTopics excluded due to pending deletion:\n")
 		for _, t := range p {
 			fmt.Printf("%s%s\n", indent, t)
 		}
 	}
+
+	if len(e) > 0 {
+		fmt.Printf("\nTopics excluded:\n")
+		for _, t := range e {
+			fmt.Printf("%s%s\n", indent, t)
+		}
+	}
 }
 
-// printMapChanges takes the original input PartitionMap
-// and the final output PartitionMap and prints what's changed.
+// printMapChanges takes the original input PartitionMap and the final output
+// PartitionMap and prints what's changed.
 func printMapChanges(pm1, pm2 *kafkazk.PartitionMap) {
-	// Ensure the topic name and partition
-	// order match.
+	// Ensure the topic name and partition order match.
 	for i := range pm1.Partitions {
 		t1, t2 := pm1.Partitions[i].Topic, pm2.Partitions[i].Topic
 		p1, p2 := pm1.Partitions[i].Partition, pm2.Partitions[i].Partition

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -21,19 +21,18 @@ func (e errors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
 // printTopics takes a partition map and prints out the names of all topics
 // referenced in the map.
 func printTopics(pm *kafkazk.PartitionMap) {
-	topics := map[string]struct{}{}
-	for _, p := range pm.Partitions {
-		topics[p.Topic] = struct{}{}
-	}
+	topics := pm.Topics()
+	sort.Strings(topics)
 
 	fmt.Printf("\nTopics:\n")
-	for t := range topics {
+	for _, t := range topics {
 		fmt.Printf("%s%s\n", indent, t)
 	}
 }
 
 func printExcludedTopics(p []string, e []string) {
 	if len(p) > 0 {
+		sort.Strings(p)
 		fmt.Printf("\nTopics excluded due to pending deletion:\n")
 		for _, t := range p {
 			fmt.Printf("%s%s\n", indent, t)
@@ -41,6 +40,7 @@ func printExcludedTopics(p []string, e []string) {
 	}
 
 	if len(e) > 0 {
+		sort.Strings(e)
 		fmt.Printf("\nTopics excluded:\n")
 		for _, t := range e {
 			fmt.Printf("%s%s\n", indent, t)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -83,11 +83,14 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	// Exclude any topics that are pending deletion.
 	pending := stripPendingDeletes(partitionMapIn, zk)
 
+	// Exclude any explicit exclusions.
+	excluded := removeTopics(partitionMapIn, Config.topicsExclude)
+
 	// Print topics matched to input params.
 	printTopics(partitionMapIn)
 
 	// Print if any topics were excluded due to pending deletion.
-	printExcludedTopics(pending, []string{})
+	printExcludedTopics(pending, excluded)
 
 	// Get a broker map.
 	brokersIn := kafkazk.BrokerMapFromPartitionMap(partitionMapIn, brokerMeta, false)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -87,7 +87,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	printTopics(partitionMapIn)
 
 	// Print if any topics were excluded due to pending deletion.
-	printExcludedTopics(pending)
+	printExcludedTopics(pending, []string{})
 
 	// Get a broker map.
 	brokersIn := kafkazk.BrokerMapFromPartitionMap(partitionMapIn, brokerMeta, false)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(rebalanceCmd)
 
 	rebalanceCmd.Flags().String("topics", "", "Rebuild topics (comma delim. list) by lookup in ZooKeeper")
+	rebalanceCmd.Flags().String("topics-exclude", "", "Exclude topics")
 	rebalanceCmd.Flags().String("out-path", "", "Path to write output map files to")
 	rebalanceCmd.Flags().String("out-file", "", "If defined, write a combined map of all topics to a file")
 	rebalanceCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)")

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -25,6 +25,7 @@ func init() {
 	rootCmd.AddCommand(rebuildCmd)
 
 	rebuildCmd.Flags().String("topics", "", "Rebuild topics (comma delim. list) by lookup in ZooKeeper")
+	rebuildCmd.Flags().String("topics-exclude", "", "Exclude topics")
 	rebuildCmd.Flags().String("map-string", "", "Rebuild a partition map provided as a string literal")
 	rebuildCmd.Flags().Bool("use-meta", true, "Use broker metadata in placement constraints")
 	rebuildCmd.Flags().String("out-path", "", "Path to write output map files to")

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -123,14 +123,15 @@ func rebuild(cmd *cobra.Command, _ []string) {
 
 	// Build a partition map either from literal map text input or by fetching the
 	// map data from ZooKeeper. Store a copy of the original.
-	partitionMapIn, pending, _ := getPartitionMap(cmd, zk)
+	partitionMapIn, pending, excluded := getPartitionMap(cmd, zk)
 	originalMap := partitionMapIn.Copy()
 
 	// Get a list of affected topics.
 	printTopics(partitionMapIn)
 
-	// Print if any topics were excluded due to pending deletion.
-	printExcludedTopics(pending)
+	// Print if any topics were excluded due to pending deletion or explicit
+	// exclusion.
+	printExcludedTopics(pending, excluded)
 
 	brokers, bs := getBrokers(cmd, partitionMapIn, brokerMeta)
 	brokersOrig := brokers.Copy()

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -123,7 +123,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 
 	// Build a partition map either from literal map text input or by fetching the
 	// map data from ZooKeeper. Store a copy of the original.
-	partitionMapIn, pending := getPartitionMap(cmd, zk)
+	partitionMapIn, pending, _ := getPartitionMap(cmd, zk)
 	originalMap := partitionMapIn.Copy()
 
 	// Get a list of affected topics.

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -44,9 +44,9 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) (*kafkazk.Partition
 		pd := stripPendingDeletes(pm, zk)
 
 		// Exclude topics explicitly listed.
-		//et := removeTopics(pm, Config.)
+		et := removeTopics(pm, Config.topicsExclude)
 
-		return pm, pd, []string{}
+		return pm, pd, et
 	}
 
 	return nil, nil, nil

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -31,8 +31,7 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) (*kafkazk.Partition
 		}
 
 		return pm, []string{}
-	// Build a map using ZooKeeper metadata
-	// for all specified topics.
+	// Build a map using ZooKeeper metadata for all specified topics.
 	case len(Config.topics) > 0:
 		pm, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
 		if err != nil {


### PR DESCRIPTION
Adds the `--exclude-topics` flag. This is used to _exclude_ topics from operations using the same syntax as the `--topics` flag (comma-separated values with regex support).

```
$ topicmappr rebuild --topics ".*" --brokers -2 --topics-exclude "test*,__consumer_offsets"               
                                                                                           
Topics:                                                                                    
  connect-offsets-km997de
  connect-status-km997de
  loadtest
                                                                                           
Topics excluded:                                                                           
  test0
  test1
  __consumer_offsets                                                                         
                                                                                           
Broker change summary:                                                                     
  Replacing 0, added 0, missing 0, total count changed by 0                               
                                                                                           
Action:                                                                                    
  no-op                                                                                    
[...]
```