### PR TITLE
Jamie/autothrottle clear stored rates

### DIFF
--- a/cmd/autothrottle/capacities.go
+++ b/cmd/autothrottle/capacities.go
@@ -48,9 +48,15 @@ func (r replicationCapacityByBroker) setAllRatesWithDefault(ids []int, rate floa
 	}
 }
 
+func (r replicationCapacityByBroker) reset() {
+	for id := range r {
+		delete(r, id)
+	}
+}
+
 // brokerReplicationCapacities traverses the list of all brokers participating
 // in the reassignment. For each broker, it determines whether the broker is
-// a leader (source) or a follower (destination), and calculates an throttle
+// a leader (source) or a follower (destination), and calculates a throttle
 // accordingly, returning a replicationCapacityByBroker and error.
 func brokerReplicationCapacities(rtc *ReplicationThrottleConfigs, reassigning reassigningBrokers, bm kafkametrics.BrokerMetrics) (replicationCapacityByBroker, error) {
 	capacities := replicationCapacityByBroker{}

--- a/cmd/autothrottle/capacities_test.go
+++ b/cmd/autothrottle/capacities_test.go
@@ -107,3 +107,20 @@ func TestStoreFollowerCapacity(t *testing.T) {
 		t.Errorf("Expected nil value, got %v", *val)
 	}
 }
+
+func TestReset(t *testing.T) {
+	capacities := replicationCapacityByBroker{}
+	capacities.setAllRatesWithDefault([]int{1001, 1002, 1003}, 100)
+
+	// Check expected len.
+	if len(capacities) != 3 {
+		t.Errorf("Expected len 3, got %d", len(capacities))
+	}
+
+	// Reset, check len.
+	capacities.reset()
+
+	if len(capacities) != 0 {
+		t.Errorf("Expected len 0, got %d", len(capacities))
+	}
+}


### PR DESCRIPTION
Adds the ability to flush the previously known throttles cache. This feature is used to ensure that out-of-sync throttle rates are periodically reconciled by flushing the cache when a reassignment is recognized as a new one.

Full details from the comments:

```
			// Unset any previously stored throttle rates. This is done to avoid a
			// scenario that results in autothrottle being unaware of externally
			// specified throttles and failing to override them. The condition can be
			// triggered when two subsequent reassignments involving the same broker
			// set are handled by autothrottle. The error condition is as follows:
			//
			// - Autothrottle sees reassignment 1 involving brokers 1001, 1002
			//   and determines a throttle rate of 100MB/s.
			// - Reassignment 1 completes, reassignment 2 is started in-between
			//   autothrottle intervals and a manual rate of 25MB/s is specified from
			//   the reassignment tool.
			// - Autothrottle sees reassignment 2, revisits throughput and determines
			//   the rate for brokers 1001 and 1002 should be 105MB/s, below the
			//   ChangeThreshold of 10% when compared to the last known rates set;
			//   throttle updates are skipped.
			// - The reassignment is now stuck at 25MB/s.
			//
			// There's two solutions considered to reconcile the stale state:
			// - Reset all previously stored rates when the current reassigning
			//   topic list is not a subset of the previous reassigning topic list.
			// - Force throttle updates every so many intervals, regardless of the
			//   required ChangeThreshold.
``` 

The second option later needs to be implemented as successive reassignments of the same topic will not be detected as two distinct reassignments.

Closes #331 