### PR TITLE
report all missing broker metrics

### DIFF
--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -50,12 +50,17 @@ func getBrokerMeta(cmd *cobra.Command, zk kafkazk.Handler, m bool) kafkazk.Broke
 // broker metadata. Any non-missing brokers in the broker map must be present
 // in the broker metadata map and have a non-true MetricsIncomplete value.
 func ensureBrokerMetrics(cmd *cobra.Command, bm kafkazk.BrokerMap, bmm kafkazk.BrokerMetaMap) {
+	var e bool
 	for id, b := range bm {
 		// Missing brokers won't be found in the brokerMeta.
 		if !b.Missing && id != kafkazk.StubBrokerID && bmm[id].MetricsIncomplete {
+			e = true
 			fmt.Printf("Metrics not found for broker %d\n", id)
-			os.Exit(1)
 		}
+	}
+
+	if e {
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
topicmappr currently errors and exits at the first broker found to have no/incomplete metrics data when using storage placement. This PR ensures that all required brokers with no/incomplete metrics data are reported.

Example: two required brokers are missing metrics.

Current output:
```
...
  New broker 10010
  New broker 30006
  New broker 30008
  New broker 30004
  -
Metrics not found for broker 10000
```

New output:
```
...
  New broker 10010
  New broker 30006
  New broker 30008
  New broker 30004
  -
Metrics not found for broker 10000
Metrics not found for broker 10001
```