### PR TITLE
Remove existing brokers check

### DIFF
--- a/registry/server/api_brokers.go
+++ b/registry/server/api_brokers.go
@@ -275,18 +275,6 @@ func (s *Server) TagBroker(ctx context.Context, req *pb.BrokerRequest) (*pb.TagR
 		return nil, err
 	}
 
-	// Ensure the broker exists.
-
-	// Get brokers from ZK.
-	brokers, errs := s.ZK.GetAllBrokerMeta(false)
-	if errs != nil {
-		return nil, ErrFetchingBrokers
-	}
-
-	if _, exist := brokers[int(req.Id)]; !exist {
-		return nil, ErrBrokerNotExist
-	}
-
 	// Set the tags.
 	id := fmt.Sprintf("%d", req.Id)
 	err = s.Tags.Store.SetTags(KafkaObject{Type: "broker", ID: id}, ts)

--- a/registry/server/api_brokers_test.go
+++ b/registry/server/api_brokers_test.go
@@ -168,7 +168,7 @@ func TestTagBroker(t *testing.T) {
 		1: ErrBrokerIDEmpty,
 		2: ErrNilTags,
 		3: ErrNilTags,
-		4: ErrBrokerNotExist,
+		4: nil, // No errors even if the broker doesn't exist.
 	}
 
 	for i, req := range tests {


### PR DESCRIPTION
This will allow you to tag brokers, even if they don't exist in zookeeper. There is already implicit support for phantom tags, because there is no clean up when a broker leaves. A change like this will be useful for systems that want to tag resources that haven't been created yet - for example, a kubernetes init container can tag a broker before it has come up yet.