### PR TITLE
Delete stale tags from Registry.

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -50,6 +50,8 @@ func main() {
 	flag.StringVar(&adminConfig.SASLMechanism, "kafka-sasl-mechanism", "", fmt.Sprintf("SASL mechanism to use for authentication. Supported: %s", strings.Join(saslMechanims, ", ")))
 	flag.StringVar(&adminConfig.SASLUsername, "kafka-sasl-username", "", "SASL username for use with the PLAIN and SASL-SCRAM-* mechanisms")
 	flag.StringVar(&adminConfig.SASLPassword, "kafka-sasl-password", "", "SASL password for use with the PLAIN and SASL-SCRAM-* mechanisms")
+	flag.IntVar(&serverConfig.TagAllowedStalenessMinutes, "tag-allowed-staleness", 60, "Minutes before tags with no associated resource are deleted")
+	flag.IntVar(&serverConfig.TagCleanupFrequencyMinutes, "tag-cleanup-frequency", 20, "Minutes between runs of tag cleanup")
 
 	kafkaVersionString := flag.String("kafka-version", "v0.10.2", "Kafka release (Semantic Versioning)")
 
@@ -116,6 +118,11 @@ func main() {
 
 	// Start the HTTP listener.
 	if err := srvr.RunHTTP(ctx, wg); err != nil {
+		log.Fatal(err)
+	}
+
+	// Start the tag cleanup background thread
+	if err := srvr.RunTagCleanup(ctx, wg, serverConfig); err != nil {
 		log.Fatal(err)
 	}
 

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -179,7 +179,7 @@ func (s *Server) RunHTTP(ctx context.Context, wg *sync.WaitGroup) error {
 }
 
 // runTagCleanup starts a background process deleting stale tags.
-func (s *Server) runTagCleanup(ctx context.Context, wg *sync.WaitGroup) error {
+func (s *Server) RunTagCleanup(ctx context.Context, wg *sync.WaitGroup, c Config) error {
 	wg.Add(1)
 	tc := TagCleaner{}
 
@@ -192,7 +192,7 @@ func (s *Server) runTagCleanup(ctx context.Context, wg *sync.WaitGroup) error {
 
 	// Background the tag cleanup mark & sweep
 	go func() {
-		tc.RunTagCleanup(s, ctx)
+		tc.RunTagCleanup(s, ctx, c)
 	}()
 
 	return nil

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -52,6 +52,8 @@ type Config struct {
 	ReadReqRate  int
 	WriteReqRate int
 	ZKTagsPrefix string
+	TagCleanupFrequencyMinutes int
+	TagAllowedStalenessMinutes int
 
 	test bool
 }
@@ -171,6 +173,26 @@ func (s *Server) RunHTTP(ctx context.Context, wg *sync.WaitGroup) error {
 		if err := srvr.ListenAndServe(); err != http.ErrServerClosed {
 			log.Println(err)
 		}
+	}()
+
+	return nil
+}
+
+// runTagCleanup starts a background process deleting stale tags.
+func (s *Server) runTagCleanup(ctx context.Context, wg *sync.WaitGroup) error {
+	wg.Add(1)
+	tc := TagCleaner{}
+
+	// Shutdown procedure.
+	go func() {
+		<-ctx.Done()
+		tc.running = false
+		wg.Done()
+	}()
+
+	// Background the tag cleanup mark & sweep
+	go func() {
+		tc.RunTagCleanup(s, ctx)
 	}()
 
 	return nil

--- a/registry/server/tag.go
+++ b/registry/server/tag.go
@@ -44,7 +44,7 @@ type TagStorage interface {
 	FieldReserved(KafkaObject, string) bool
 	SetTags(KafkaObject, TagSet) error
 	GetTags(KafkaObject) (TagSet, error)
-	DeleteTags(KafkaObject, Tags) error
+	DeleteTags(KafkaObject, []string) error
 	GetAllTags() (map[KafkaObject]TagSet, error)
 }
 

--- a/registry/server/tag.go
+++ b/registry/server/tag.go
@@ -45,6 +45,7 @@ type TagStorage interface {
 	SetTags(KafkaObject, TagSet) error
 	GetTags(KafkaObject) (TagSet, error)
 	DeleteTags(KafkaObject, Tags) error
+	GetAllTags() (map[KafkaObject]TagSet, error)
 }
 
 // NewTagHandler initializes a TagHandler.

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -1,0 +1,17 @@
+package server
+
+import "context"
+
+func(s *Server) markForDeletion(ctx context.Context) error {
+
+	// Get brokers from ZK.
+	brokers, errs := s.ZK.GetAllBrokerMeta(false)
+	if errs != nil {
+		return ErrFetchingBrokers
+	}
+
+	for b, _ := range brokers  {
+		tags, err := s.Tags.Store.GetTags(KafkaObject{ID: string(b), Type: "broker"})
+	}
+
+}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -91,7 +91,13 @@ func(s *Server) DeleteStaleTags(now func() time.Time, c Config) {
 		}
 
 		if sweepTime - int64(markTime) > int64(c.TagAllowedStalenessMinutes * 60) {
-			s.Tags.Store.DeleteTags(kafkaObject, tags.Tags())
+			keys := make([]string, len(tags))
+			i := 0
+			for k := range tags {
+				keys[i] = k
+				i++
+			}
+			s.Tags.Store.DeleteTags(kafkaObject, keys)
 		}
 	}
 }

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var TagMarkTimeKey = "tagMarkedForDeletionTSMin"
+var TagMarkTimeKey = "tagMarkedForDeletionTime"
 var topicRegex = regexp.MustCompile(".*")
 
 type TagCleaner struct {
@@ -63,10 +63,14 @@ func(s *Server) MarkForDeletion(now func() time.Time) error {
 			}
 			if _, exists := brokers[brokerId]; !exists {
 				tagSet[TagMarkTimeKey] = markTimeMinutes
+			} else {
+				delete(tagSet, TagMarkTimeKey)
 			}
 		case "topic":
 			if _, exists := topicSet[kafkaObject.ID]; !exists {
 				tagSet[TagMarkTimeKey] = markTimeMinutes
+			} else {
+				delete(tagSet, TagMarkTimeKey)
 			}
 		}
 	}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -1,17 +1,82 @@
 package server
 
-import "context"
+import (
+	"context"
+	regexp2 "regexp"
+	"strconv"
+	"time"
+)
 
-func(s *Server) markForDeletion(ctx context.Context) error {
+var tagMarkTimeKey = "tagMarkedForDeletionTSMin"
+var allowedTagStalenessMinutes = 60 // todo: pass this through via config
 
-	// Get brokers from ZK.
+// todo: should I handle errors, or just log?
+// todo: what calls this function? A timer? Should anything happen if it fails?
+// MarkForDeletion marks stored tags that have been stranded without an associated kafka resource.
+func(s *Server) MarkForDeletion(ctx context.Context) error {
+	markTimeMinutes := string(time.Now().Minute())
+
+	// Get all brokers from ZK.
 	brokers, errs := s.ZK.GetAllBrokerMeta(false)
 	if errs != nil {
 		return ErrFetchingBrokers
 	}
 
-	for b, _ := range brokers  {
-		tags, err := s.Tags.Store.GetTags(KafkaObject{ID: string(b), Type: "broker"})
+	// Get all topics from ZK
+	rgex, _ := regexp2.Compile(".*")
+	regexes := []*regexp2.Regexp{rgex}
+	topics, err := s.ZK.GetTopics(regexes)
+	if err != nil {
+		// todo
+	}
+	topicSet := TopicSetFromSlice(topics)
+
+	allTags, _ := s.Tags.Store.GetAllTags()
+
+	// Add a marker tag with timestamp to any dangling tagset whose associated kafka resource no longer exists.
+	for kafkaObject, tagSet := range allTags {
+		switch kafkaObject.Type {
+		case "broker":
+			brokerId, err := strconv.Atoi(kafkaObject.ID)
+			if err != nil {
+				// todo
+			}
+			if _, exists := brokers[brokerId]; exists {
+				tagSet[tagMarkTimeKey] = markTimeMinutes
+			}
+		case "topic":
+			if _, exists := topicSet[kafkaObject.ID]; exists {
+				tagSet[tagMarkTimeKey] = markTimeMinutes
+			}
+		}
 	}
 
+	return nil
+}
+
+// DeleteStaleTags deletes any tags that have not had a kafka resource associated with them.
+func(s *Server) DeleteStaleTags(ctx context.Context) {
+	sweepTimeMinutes := time.Now().Minute()
+	allTags, _ := s.Tags.Store.GetAllTags()
+
+	for kafkaObject, tags := range allTags {
+		markTag := tags[tagMarkTimeKey]
+		markTime, err := strconv.Atoi(markTag)
+		if err != nil {
+			// todo
+		}
+
+		if sweepTimeMinutes - markTime < allowedTagStalenessMinutes {
+			s.Tags.Store.DeleteTags(kafkaObject, tags.Tags())
+		}
+	}
+}
+
+// TopicSetFromSlice converts a slice into a TopicSet for convenience
+func TopicSetFromSlice(s []string) TopicSet {
+	var ts = TopicSet{}
+	for _, t := range s {
+		ts[t] = nil // TODO: I hope this works assigning nil...
+	}
+	return ts
 }

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -85,8 +85,11 @@ func(s *Server) DeleteStaleTags(now func() time.Time, c Config) {
 	allTags, _ := s.Tags.Store.GetAllTags()
 
 	for kafkaObject, tags := range allTags {
-		markTag := tags[TagMarkTimeKey]
+		markTag, exists := tags[TagMarkTimeKey]
 		markTime, err := strconv.Atoi(markTag)
+		if !exists {
+			continue
+		}
 		if err != nil {
 			log.Printf("Found non timestamp tag %s in stale tag marker\n", markTag)
 		}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -73,6 +73,7 @@ func(s *Server) MarkForDeletion(now func() time.Time) error {
 				delete(tagSet, TagMarkTimeKey)
 			}
 		}
+		s.Tags.Store.SetTags(kafkaObject, tagSet) // Persist any changes
 	}
 
 	return nil

--- a/registry/server/tag_cleanup_test.go
+++ b/registry/server/tag_cleanup_test.go
@@ -17,7 +17,7 @@ func TestMarkStaleTags(t *testing.T) {
 
 	// This broker is not in our zk stub
 	nbt := TagSet{"stale": "tag"}
-	noBroker := KafkaObject{Type: "broker", ID: "not found"}
+	noBroker := KafkaObject{Type: "broker", ID: "34"}
 
 	zk := kafkazk.NewZooKeeperStub()
 	th := testTagHandler()

--- a/registry/server/tag_cleanup_test.go
+++ b/registry/server/tag_cleanup_test.go
@@ -74,17 +74,26 @@ func TestKafkaObjectComesBack(t *testing.T) {
 	bt := TagSet{"foo": "bar", TagMarkTimeKey: "12345"} // pretend this broker was marked for tag deletion previously
 	broker := KafkaObject{Type: "broker", ID: "1002"} // but this broker now exists in our stub, so the marker will be removed.
 
+	tt := TagSet{"bing": "baz", TagMarkTimeKey: "12345"} // same for a topic.
+	topic := KafkaObject{Type: "topic", ID: "test_topic"}
+
 	zk := kafkazk.NewZooKeeperStub()
 	th := testTagHandler()
 	s := Server{Tags: th, ZK: zk}
 
 	// WHEN
 	th.Store.SetTags(broker, bt)
+	th.Store.SetTags(topic, tt)
 	s.MarkForDeletion(time.Now)
 
 	// THEN
 	btags, _ := th.Store.GetTags(broker)
 	if _, exists := btags[TagMarkTimeKey]; exists {
 		t.Errorf("Expected mark for broker %s to be removed.", broker)
+	}
+
+	ttags, _ := th.Store.GetTags(topic)
+	if _, exists := ttags[TagMarkTimeKey]; exists {
+		t.Errorf("Expected mark for topic %s to be removed.", topic)
 	}
 }

--- a/registry/server/tag_cleanup_test.go
+++ b/registry/server/tag_cleanup_test.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"fmt"
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
 	"testing"
+	"time"
 )
 
 func TestMarkStaleTags(t *testing.T) {
+	// GIVEN
 	bt := TagSet{"foo": "bar"}
 	broker := KafkaObject{Type: "broker", ID: "1002"}
 
@@ -16,17 +19,17 @@ func TestMarkStaleTags(t *testing.T) {
 	nbt := TagSet{"stale": "tag"}
 	noBroker := KafkaObject{Type: "broker", ID: "not found"}
 
+	zk := kafkazk.NewZooKeeperStub()
 	th := testTagHandler()
+	s := Server{Tags: th, ZK: zk}
+
+	// WHEN
 	th.Store.SetTags(topic, tt)
 	th.Store.SetTags(broker, bt)
 	th.Store.SetTags(noBroker, nbt)
+	s.MarkForDeletion(time.Now)
 
-	zk := kafkazk.NewZooKeeperStub()
-
-	s := Server{Tags: th, ZK: zk}
-
-	s.MarkForDeletion()
-
+	// THEN
 	nbtags, _ := th.Store.GetTags(noBroker)
 	if _, exists := nbtags[TagMarkTimeKey]; !exists {
 		t.Errorf("Expected tags for broker %s to be marked for cleanup.", noBroker)
@@ -40,5 +43,26 @@ func TestMarkStaleTags(t *testing.T) {
 	btags, _ := th.Store.GetTags(broker)
 	if _, exists := btags[TagMarkTimeKey]; exists {
 		t.Errorf("Expected tags for broker %s to not be marked for cleanup.", broker)
+	}
+}
+
+func TestDeleteStaleTags(t *testing.T) {
+	markTime := time.Date(2020, 1, 2, 3, 0, 0, 0, time.UTC)
+	sweepTime := markTime.Add(15 * time.Minute)
+
+	bt := TagSet{"foo": "bar", TagMarkTimeKey: fmt.Sprint(markTime.Unix())}
+	broker := KafkaObject{Type: "broker", ID: "not found"}
+
+	th := testTagHandler()
+	zk := kafkazk.NewZooKeeperStub()
+	s := Server{Tags: th, ZK: zk}
+
+	th.Store.SetTags(broker, bt)
+
+	s.DeleteStaleTags(func() time.Time { return sweepTime }, Config{TagAllowedStalenessMinutes: 10})
+
+	btags, _ := th.Store.GetTags(broker)
+	if len(btags) > 0 {
+		t.Errorf("Expected marked tags for broker %s to be deleted.", broker)
 	}
 }

--- a/registry/server/tag_cleanup_test.go
+++ b/registry/server/tag_cleanup_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	"testing"
+)
+
+func TestMarkStaleTags(t *testing.T) {
+	bt := TagSet{"foo": "bar"}
+	broker := KafkaObject{Type: "broker", ID: "1002"}
+
+	tt := TagSet{"bing": "baz"}
+	topic := KafkaObject{Type: "topic", ID: "test_topic"}
+
+	// This broker is not in our zk stub
+	nbt := TagSet{"stale": "tag"}
+	noBroker := KafkaObject{Type: "broker", ID: "not found"}
+
+	th := testTagHandler()
+	th.Store.SetTags(topic, tt)
+	th.Store.SetTags(broker, bt)
+	th.Store.SetTags(noBroker, nbt)
+
+	zk := kafkazk.NewZooKeeperStub()
+
+	s := Server{Tags: th, ZK: zk}
+
+	s.MarkForDeletion()
+
+	nbtags, _ := th.Store.GetTags(noBroker)
+	if _, exists := nbtags[TagMarkTimeKey]; !exists {
+		t.Errorf("Expected tags for broker %s to be marked for cleanup.", noBroker)
+	}
+
+	ttags, _ := th.Store.GetTags(topic)
+	if _, exists := ttags[TagMarkTimeKey]; exists {
+		t.Errorf("Expected tags for topic %s to not be marked for cleanup.", topic)
+	}
+
+	btags, _ := th.Store.GetTags(broker)
+	if _, exists := btags[TagMarkTimeKey]; exists {
+		t.Errorf("Expected tags for broker %s to not be marked for cleanup.", broker)
+	}
+}

--- a/registry/server/tagstorage_zk.go
+++ b/registry/server/tagstorage_zk.go
@@ -223,14 +223,14 @@ func (t *ZKTagStorage) GetAllTagsForType(kafkaObjectType string) (map[KafkaObjec
 	return objectTags, nil
 }
 
-// DeleteTags deletes all tags in the Tags for the requested KafkaObject.
-func (t *ZKTagStorage) DeleteTags(o KafkaObject, ts Tags) error {
+// DeleteTags deletes all tags in the list of keys for the requested KafkaObject.
+func (t *ZKTagStorage) DeleteTags(o KafkaObject, keysToDelete []string) error {
 	// Sanity checks.
 	if !o.Complete() {
 		return ErrInvalidKafkaObjectType
 	}
 
-	if len(ts) == 0 {
+	if len(keysToDelete) == 0 {
 		return ErrNilTags
 	}
 
@@ -258,7 +258,7 @@ func (t *ZKTagStorage) DeleteTags(o KafkaObject, ts Tags) error {
 	}
 
 	// Delete listed tags.
-	for _, k := range ts {
+	for _, k := range keysToDelete {
 		delete(tags, k)
 	}
 

--- a/registry/server/tagstorage_zk.go
+++ b/registry/server/tagstorage_zk.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
@@ -206,8 +205,8 @@ func (t *ZKTagStorage) GetAllTagsForType(kafkaObjectType string) (map[KafkaObjec
 
 	objectTags := map[KafkaObject]TagSet{}
 
-	for objectId := range children {
-		object := KafkaObject{Type: kafkaObjectType, ID: strconv.Itoa(objectId)}
+	for _, objectId := range children {
+		object := KafkaObject{Type: kafkaObjectType, ID: objectId}
 		tags, err := t.GetTags(object)
 		if err != nil {
 			switch err.(type) {

--- a/registry/server/tagstorage_zk.go
+++ b/registry/server/tagstorage_zk.go
@@ -167,7 +167,7 @@ func (t *ZKTagStorage) GetTags(o KafkaObject) (TagSet, error) {
 	return tags, nil
 }
 
-// GetAllTags returns all tags stored in the tagstore, grouped by kafka object.
+// GetAllTags returns all tags stored in the tagstore, keyed by the resource they correspond to.
 func (t *ZKTagStorage) GetAllTags() (map[KafkaObject]TagSet, error) {
 
 	tags := map[KafkaObject]TagSet{}

--- a/registry/server/tagstorage_zk_stub_test.go
+++ b/registry/server/tagstorage_zk_stub_test.go
@@ -87,8 +87,16 @@ func (t *zkTagStorageStub) DeleteTags(o KafkaObject, tl Tags) error {
 
 // GetAllTags stubs GetAllTags
 func (t *zkTagStorageStub) GetAllTags() (map[KafkaObject]TagSet, error) {
-	// todo: implement
-	return nil, nil
+	ts := map[KafkaObject]TagSet{}
+
+	// just flattens and returns all tag sets.
+	for objectType, objects := range t.tags {
+		for o, tags := range objects {
+			ts[KafkaObject{Type: objectType, ID: o}] = tags
+		}
+	}
+
+	return ts, nil
 }
 
 // FieldReserved stubs FieldReserved.

--- a/registry/server/tagstorage_zk_stub_test.go
+++ b/registry/server/tagstorage_zk_stub_test.go
@@ -78,7 +78,8 @@ func (t *zkTagStorageStub) DeleteTags(o KafkaObject, tl Tags) error {
 		return ErrKafkaObjectDoesNotExist
 	}
 
-	for _, k := range tl {
+	tagSet, _ := tl.TagSet()
+	for k, _ := range tagSet {
 		delete(t.tags[o.Type][o.ID], k)
 	}
 

--- a/registry/server/tagstorage_zk_stub_test.go
+++ b/registry/server/tagstorage_zk_stub_test.go
@@ -85,6 +85,12 @@ func (t *zkTagStorageStub) DeleteTags(o KafkaObject, tl Tags) error {
 	return nil
 }
 
+// GetAllTags stubs GetAllTags
+func (t *zkTagStorageStub) GetAllTags() (map[KafkaObject]TagSet, error) {
+	// todo: implement
+	return nil, nil
+}
+
 // FieldReserved stubs FieldReserved.
 func (t *zkTagStorageStub) FieldReserved(o KafkaObject, f string) bool {
 	if !o.Valid() {

--- a/registry/server/tagstorage_zk_stub_test.go
+++ b/registry/server/tagstorage_zk_stub_test.go
@@ -65,7 +65,7 @@ func (t *zkTagStorageStub) GetTags(o KafkaObject) (TagSet, error) {
 }
 
 // DeleteTags stubs DeleteTags.
-func (t *zkTagStorageStub) DeleteTags(o KafkaObject, tl Tags) error {
+func (t *zkTagStorageStub) DeleteTags(o KafkaObject, keysToDelete []string) error {
 	if !o.Complete() {
 		return ErrInvalidKafkaObjectType
 	}
@@ -78,8 +78,7 @@ func (t *zkTagStorageStub) DeleteTags(o KafkaObject, tl Tags) error {
 		return ErrKafkaObjectDoesNotExist
 	}
 
-	tagSet, _ := tl.TagSet()
-	for k, _ := range tagSet {
+	for _, k := range keysToDelete {
 		delete(t.tags[o.Type][o.ID], k)
 	}
 


### PR DESCRIPTION
Currently, when a broker or topic leaves the cluster, there is no cleanup process for the leftover tags. This can be problematic for setups that reuse broker IDs, as the new broker will inherit the old tags and they may not match up. Potentially relevant also for topics that are deleted and recreated.

Putting a WIP PR to get some early feedback.