### PR TITLE
jamie/tag-cleanup

### DIFF
--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -21,7 +21,7 @@ func (tc *TagCleaner) RunTagCleanup(s *Server, ctx context.Context, c Config) {
 	tc.running = true
 
 	// Interval timer.
-	t := time.NewTicker(time.Duration(c.TagCleanupFrequencyMinutes) * time.Second)
+	t := time.NewTicker(time.Duration(c.TagCleanupFrequencyMinutes) * time.Minute)
 	defer t.Stop()
 
 	for tc.running {

--- a/registry/server/tagstorage_zk.go
+++ b/registry/server/tagstorage_zk.go
@@ -171,18 +171,26 @@ func (t *ZKTagStorage) GetAllTags() (map[KafkaObject]TagSet, error) {
 
 	tags := map[KafkaObject]TagSet{}
 
+	// Get all broker tags.
 	brokerTags, err := t.GetAllTagsForType("broker")
-	if err != nil {
+	// Don't return if the parent broker tag znode doesn't exist; this just
+	// means no tags were ever set.
+	if err != nil && err != ErrKafkaObjectDoesNotExist {
 		return nil, err
 	}
+
 	for broker, brokerTags := range brokerTags {
 		tags[broker] = brokerTags
 	}
 
+	// Get all topic tags.
 	topicTags, err := t.GetAllTagsForType("topic")
-	if err != nil {
+	// Don't return if the parent topic tag znode doesn't exist; this just
+	// means no tags were ever set.
+	if err != nil && err != ErrKafkaObjectDoesNotExist {
 		return nil, err
 	}
+
 	for topic, topicTags := range topicTags {
 		tags[topic] = topicTags
 	}
@@ -192,7 +200,7 @@ func (t *ZKTagStorage) GetAllTags() (map[KafkaObject]TagSet, error) {
 
 // GetAllTagsForType gets all the tags for objects of the given type. A convenience method that makes getting every tag a little easier.
 func (t *ZKTagStorage) GetAllTagsForType(kafkaObjectType string) (map[KafkaObject]TagSet, error) {
-	zNode := fmt.Sprintf("/%s/%s/", t.Prefix, kafkaObjectType)
+	zNode := fmt.Sprintf("/%s/%s", t.Prefix, kafkaObjectType)
 	children, err := t.ZK.Children(zNode)
 	if err != nil {
 		switch err.(type) {

--- a/registry/server/tagstorage_zk_integration_test.go
+++ b/registry/server/tagstorage_zk_integration_test.go
@@ -160,7 +160,7 @@ func TestGetTags(t *testing.T) {
 		}
 
 		if !tags.Equal(expected[k]) {
-			t.Errorf("[test %d] Expected TagSet '%v', got '%v'",
+			t.Errorf("[test %d] Expected TagSet '%+v', got '%+v'",
 				k, expected[k], tags)
 		}
 	}
@@ -207,12 +207,12 @@ func TestGetAllTags(t *testing.T) {
 	// Fetch tags, compare value.
 	tags, _ := store.GetAllTags()
 
-	for k := range testTagSets {
-		obj := testObjects[k]
-		expectedTags := expected[k]
-		if reflect.DeepEqual(tags[obj], expectedTags) {
-			t.Errorf("[test %d] Expected TagSet '%v', got '%v'",
-				k, expected[k], tags)
+	for k, obj := range testObjects {
+		got := tags[obj]
+		expected := expected[k]
+		t.Logf("%+v", got)
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("[test %d] Expected TagSet '%+v', got '%+v'", k, expected, got)
 		}
 	}
 }
@@ -258,7 +258,7 @@ func TestDeleteTags(t *testing.T) {
 		}
 
 		if !tags.Equal(expected[k]) {
-			t.Errorf("[test %d] Expected TagSet '%v', got '%v'",
+			t.Errorf("[test %d] Expected TagSet '%+v', got '%+v'",
 				k, expected[k], tags)
 		}
 	}


### PR DESCRIPTION
- Minor bug: ticker intended to run at minute intervals runs at seconds interval
- Bug: zk tag storage has a trailing slash in the znode path
- Improvement: error type handling in tag lookups
- Bug: fixes `GetAllTags` test