### PR TITLE
Jamie/tagset cleanup

### DIFF
--- a/registry/server/tag.go
+++ b/registry/server/tag.go
@@ -280,6 +280,17 @@ func (t TagSet) Tags() Tags {
 	return ts
 }
 
+// Keys returns a []string of all tag keys for a TagSet.
+func (t TagSet) Keys() []string {
+	var keys []string
+
+	for k := range t {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
 // TagSet takes a Tags and returns a TagSet and error for any
 // malformed tags. Tags are expected to be formatted as a
 // comma delimited "key:value,key2:value2" string.

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -85,7 +85,7 @@ func (s *Server) MarkForDeletion(now func() time.Time) error {
 		if !objectExists && !marked {
 			tagSet[TagMarkTimeKey] = markTimeMinutes
 			if err := s.Tags.Store.SetTags(kafkaObject, tagSet); err != nil {
-				log.Printf("failed to update TagSet for %s %s: %s", kafkaObject.Type, kafkaObject.ID, err)
+				log.Printf("failed to update TagSet for %s %s: %s\n", kafkaObject.Type, kafkaObject.ID, err)
 			}
 			continue
 		}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -116,12 +116,8 @@ func (s *Server) DeleteStaleTags(now func() time.Time, c Config) {
 			// This object has tags being deleted; add it to the set.
 			deletedObjects[kafkaObject] = struct{}{}
 
-			keys := make([]string, len(tags))
-			i := 0
-			for k := range tags {
-				keys[i] = k
-				i++
-			}
+			keys := tags.Keys()
+
 			s.Tags.Store.DeleteTags(kafkaObject, keys)
 		}
 	}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -63,7 +63,6 @@ func (s *Server) MarkForDeletion(now func() time.Time) error {
 	// Add a marker tag with timestamp to any dangling tagset whose associated kafka
 	// resource no longer exists.
 	for kafkaObject, tagSet := range allTags {
-		var removeTagMarkTimeKey bool
 		var objectExists bool
 
 		// Check whether the object currently exists.


### PR DESCRIPTION
Updates the `MarkForDeletion` function which is responsible for tracking stale objects (brokers, topics) and marking them with expiry timestamps:

- We log when tags are deleted
- Avoids re-updating previously marked objects
- Call `SetTags` only when appending the marker tag
- Call `DeleteTags` when deleting tags; avoids attempts to set empty tags plus avoids a scenario where an object with no tags goes away -> is marked -> comes back -> we fail to remove the marker (because the tag set would go from `{marker}` to `{}`, and we can't set empty sets) 