### PR TITLE
Avoid printing anything when autothrottle is no-op

### DIFF
--- a/cmd/autothrottle/throttles_update.go
+++ b/cmd/autothrottle/throttles_update.go
@@ -299,6 +299,10 @@ func applyBrokerThrottles(bs map[int]struct{}, capacities, prevThrottles replica
 				max = l["dstMax"]
 			}
 
+			if *prevRate == *rate {
+				continue
+			}
+
 			log.Printf("Replication throttle rate for broker %d [%s] (based on a %.0f%% max free capacity utilization): %0.2fMB/s\n",
 				ID, role, max, *rate)
 


### PR DESCRIPTION
Whenever there is no change to the throttle rate, autothrottle was still
saying "Proposed throttle is within 0.00% of the previous throttle"
message and the "Replication throttle rate for broker....", which was a
bit misleading because in that case, autothrottle was actually changing
nothing to the system state.

Makes it silent when nothing change.

<img width="1238" alt="Screen Shot 2021-10-21 at 4 34 51 PM" src="https://user-images.githubusercontent.com/86608/138430450-ff075e6a-aef8-44ea-bcf5-68a46bcacd3c.png">


