### PR TITLE
fixes error overwrite

### DIFF
--- a/kafkametrics/datadog/metrics.go
+++ b/kafkametrics/datadog/metrics.go
@@ -99,7 +99,7 @@ func (h *ddHandler) brokerMetricsFromList(l []*kafkametrics.Broker) (kafkametric
 	brokers := kafkametrics.BrokerMetrics{}
 	errs = populateFromTagMap(brokers, h.tagCache, tags, h.brokerIDTag)
 	if errs != nil {
-		errs = append(errors, errs...)
+		errors = append(errors, errs...)
 	}
 
 	return brokers, errors


### PR DESCRIPTION
Tag missing errors in autothrottle were being suppressed. This PR fixes the problem so that errors are correctly reported.