### PR TITLE
adds missing Endpoint field

### DIFF
--- a/kafkazk/zookeeper_integration_test.go
+++ b/kafkazk/zookeeper_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafkazk

--- a/registry/server/api_brokers.go
+++ b/registry/server/api_brokers.go
@@ -372,6 +372,7 @@ func pbBrokerFromMeta(id uint32, b *kafkazk.BrokerMeta) *pb.Broker {
 		Listenersecurityprotocolmap: b.ListenerSecurityProtocolMap,
 		Rack:                        b.Rack,
 		Jmxport:                     uint32(b.JMXPort),
+		Endpoints:                   b.Endpoints,
 		Host:                        b.Host,
 		Timestamp:                   ts,
 		Port:                        uint32(b.Port),

--- a/registry/server/api_integration_test.go
+++ b/registry/server/api_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package server

--- a/registry/server/tagstorage_zk_integration_test.go
+++ b/registry/server/tagstorage_zk_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package server

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
The `Endpoints` field in broker requests is currently excluded. This PR ensures that this data is populated:

Before:
```
% curl localhost:8080/v1/brokers | jq
{
  "brokers": {
    "1001": {
      "tags": {},
      "id": 1001,
      "listenersecurityprotocolmap": {
        "SASL_SSL": "SASL_SSL"
      },
      "endpoints": [],
      "rack": "1a",
      "jmxport": 4294967295,
      "host": "",
      "timestamp": "1639164094045",
      "port": 4294967295,
      "version": 4
    }
  },
  "ids": []
}
```

After:
```
% curl localhost:8080/v1/brokers | jq
{
  "brokers": {
    "1001": {
      "tags": {},
      "id": 1001,
      "listenersecurityprotocolmap": {
        "SASL_SSL": "SASL_SSL"
      },
      "endpoints": [
        "SASL_SSL://733fad76d5be:9093"
      ],
      "rack": "1a",
      "jmxport": 4294967295,
      "host": "",
      "timestamp": "1639164094045",
      "port": 4294967295,
      "version": 4
    }
  },
  "ids": []
}
```