### PR TITLE
Jamie/context lock state

### DIFF
--- a/cluster/zookeeper/locking.go
+++ b/cluster/zookeeper/locking.go
@@ -18,8 +18,6 @@ func (z *ZooKeeperLock) Lock(ctx context.Context) error {
 
 	// Check if the context has a lock owner value. If so, check if this owner
 	// already has the lock.
-	fmt.Println("owner: ", z.owner)
-	fmt.Println("this context: ", ctx.Value(z.OwnerKey))
 	if owner := ctx.Value(z.OwnerKey); owner != nil && owner == z.owner {
 		return nil
 	}

--- a/cluster/zookeeper/locking_test.go
+++ b/cluster/zookeeper/locking_test.go
@@ -22,6 +22,21 @@ func TestLock(t *testing.T) {
 	assert.Equal(t, err2, ErrLockingTimedOut, "Expected ErrLockingTimedOut")
 }
 
+func TestLockSameOwner(t *testing.T) {
+	lock := newMockZooKeeperLock()
+	ctx, cf := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx = context.WithValue(ctx, "owner", "owner")
+	_ = cf
+
+	// This lock should succeed normally.
+	err := lock.Lock(ctx)
+	assert.Nil(t, err)
+
+	// This should also succeed because we have the same instance, same owner key/value.
+	err2 := lock.Lock(ctx)
+	assert.Nil(t, err2)
+}
+
 func TestUnlock(t *testing.T) {
 	lock := newMockZooKeeperLock()
 	ctx, cf := context.WithTimeout(context.Background(), 1*time.Second)

--- a/cluster/zookeeper/zookeeper_test_mock.go
+++ b/cluster/zookeeper/zookeeper_test_mock.go
@@ -25,14 +25,16 @@ func newMockZooKeeperLock() *ZooKeeperLock {
 			nextID:            0,
 			path:              "/locks",
 		},
-		Path: "/locks",
+		OwnerKey: "owner",
+		Path:     "/locks",
 	}
 }
 
 func newMockZooKeeperLockWithClient(c *mockZooKeeperClient) *ZooKeeperLock {
 	return &ZooKeeperLock{
-		c:    c,
-		Path: "/locks",
+		c:        c,
+		Path:     "/locks",
+		OwnerKey: "owner",
 	}
 }
 

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -277,8 +277,9 @@ func (s *Server) InitKafkaConsumer(ctx context.Context, wg *sync.WaitGroup, cfg 
 // EnablingLocking uses distributed locking for write operations.
 func (s *Server) EnablingLocking(c *kafkazk.Config) error {
 	cfg := zklocking.ZooKeeperLockConfig{
-		Address: c.Connect,
-		Path:    "/registry/locks",
+		Address:  c.Connect,
+		Path:     "/registry/locks",
+		OwnerKey: "reqID",
 	}
 
 	zkl, err := zklocking.NewZooKeeperLock(cfg)


### PR DESCRIPTION
Adds a feature to the `cluster/zookeeper` Lock implementation that allows successive `Lock()` calls to succeed from a given `ZooKeeperLock` instance where the owner ID is the same. The owner ID key is configurable and is specified in the request context.

This also updates the Registry to use the lock ownership feature, setting the request ID to the owner value. This prevents cases where a single request that may require multiple locks to not deadlock itself.