### PR TITLE
Jamie/unlock fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,6 @@ RUN apt-get update && apt-get install -y librdkafka1 librdkafka-dev >/dev/null
 
 # Init repo.
 WORKDIR /go/src/github.com/DataDog/kafka-kit
-COPY cmd cmd
-COPY cluster cluster
-COPY kafkaadmin kafkaadmin
-COPY kafkametrics kafkametrics
-COPY kafkazk kafkazk
-COPY registry registry
 COPY tools.go tools.go
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -44,6 +38,14 @@ RUN go install \
   google.golang.org/protobuf/cmd/protoc-gen-go \
   google.golang.org/grpc/cmd/protoc-gen-go-grpc \
   github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+
+# Copy source.
+COPY cmd cmd
+COPY cluster cluster
+COPY kafkaadmin kafkaadmin
+COPY kafkametrics kafkametrics
+COPY kafkazk kafkazk
+COPY registry registry
 
 # Codegen
 RUN protoc -I ./registry -I $GOPATH/pkg/mod/$(awk '/googleapis/ {printf "%s@%s", $1, $2}' go.mod) \

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -13,4 +13,6 @@ type Lock interface {
 	// through this interface. A context is accepted for setting wait bounds.
 	Lock(context.Context) error
 	Unlock(context.Context) error
+	// Owner returns the current owner value.
+	Owner() interface{}
 }

--- a/cluster/zookeeper/errors.go
+++ b/cluster/zookeeper/errors.go
@@ -12,6 +12,8 @@ var (
 	// ErrInvalidSeqNode is returned when sequential znodes are being parsed for
 	// a trailing integer ID, but one isn't found.
 	ErrInvalidSeqNode = errors.New("znode doesn't appear to be a sequential type")
+	// ErrNotLockOwner
+	ErrNotLockOwner = errors.New("non-owner attempted to call unlock")
 )
 
 // ErrLockingFailed is a general failure.

--- a/cluster/zookeeper/errors.go
+++ b/cluster/zookeeper/errors.go
@@ -12,8 +12,12 @@ var (
 	// ErrInvalidSeqNode is returned when sequential znodes are being parsed for
 	// a trailing integer ID, but one isn't found.
 	ErrInvalidSeqNode = errors.New("znode doesn't appear to be a sequential type")
-	// ErrNotLockOwner
+	// ErrNotLockOwner is returned when Unlock is attempting to be called where the
+	// requestor's OwnerKey value does not equal the current lock owner.
 	ErrNotLockOwner = errors.New("non-owner attempted to call unlock")
+	// ErrOwnerAlreadySet is returned when SetOwner is being called on a lock where
+	// the owner field is non-nil.
+	ErrOwnerAlreadySet = errors.New("attempt to set owner on a claimed lock")
 )
 
 // ErrLockingFailed is a general failure.

--- a/cluster/zookeeper/errors.go
+++ b/cluster/zookeeper/errors.go
@@ -6,6 +6,9 @@ import (
 )
 
 var (
+	// ErrAlreadyOwnLock is returned if Lock is called with a context holding an
+	// OwnerKey equal to that of an active lock.
+	ErrAlreadyOwnLock = errors.New("requestor already has an active lock")
 	// ErrLockingTimedOut is returned when a lock couldn't be acquired  by the
 	// context deadline.
 	ErrLockingTimedOut = errors.New("attempt to acquire lock timed out")

--- a/cluster/zookeeper/locking.go
+++ b/cluster/zookeeper/locking.go
@@ -13,7 +13,7 @@ import (
 func (z *ZooKeeperLock) Lock(ctx context.Context) error {
 	// Check if the context has a lock owner value. If so, check if this owner
 	// already has the lock.
-	if owner := ctx.Value(z.OwnerKey); owner != nil && owner == z.owner {
+	if owner := ctx.Value(z.OwnerKey); owner != nil && owner == z.Owner() {
 		return nil
 	}
 
@@ -48,12 +48,15 @@ func (z *ZooKeeperLock) Lock(ctx context.Context) error {
 		firstClaim, _ := locks.First()
 		if thisID == firstClaim {
 			// We have the lock.
+			z.mu.Lock()
+			// Update the lock znode.
 			z.lockZnode, err = locks.LockPath(thisID)
-
 			// Set the owner value if the context OwnerKey is specified.
 			if owner := ctx.Value(z.OwnerKey); owner != nil {
 				z.owner = owner
 			}
+
+			z.mu.Unlock()
 
 			return nil
 		}
@@ -87,7 +90,7 @@ func (z *ZooKeeperLock) Lock(ctx context.Context) error {
 // Unlock releases a lock.
 func (z *ZooKeeperLock) Unlock(ctx context.Context) error {
 	// Check if the context has a lock owner value.
-	if owner := ctx.Value(z.OwnerKey); owner != nil && owner != z.owner {
+	if owner := ctx.Value(z.OwnerKey); owner != nil && owner != z.Owner() {
 		return ErrNotLockOwner
 	}
 
@@ -95,8 +98,10 @@ func (z *ZooKeeperLock) Unlock(ctx context.Context) error {
 		return ErrUnlockingFailed{message: err.Error()}
 	}
 
+	z.mu.Lock()
 	z.lockZnode = ""
 	z.owner = nil
+	z.mu.Unlock()
 
 	return nil
 }

--- a/cluster/zookeeper/locking.go
+++ b/cluster/zookeeper/locking.go
@@ -14,7 +14,7 @@ func (z *ZooKeeperLock) Lock(ctx context.Context) error {
 	// Check if the context has a lock owner value. If so, check if this owner
 	// already has the lock.
 	if owner := ctx.Value(z.OwnerKey); owner != nil && owner == z.Owner() {
-		return nil
+		return ErrAlreadyOwnLock
 	}
 
 	// Enter the claim into ZooKeeper.

--- a/cluster/zookeeper/locking_test.go
+++ b/cluster/zookeeper/locking_test.go
@@ -32,9 +32,10 @@ func TestLockSameOwner(t *testing.T) {
 	err := lock.Lock(ctx)
 	assert.Nil(t, err)
 
-	// This should also succeed because we have the same instance, same owner key/value.
+	// This should also succeed (with a soft error) because we have the same
+	// instance, same owner key/value.
 	err2 := lock.Lock(ctx)
-	assert.Nil(t, err2)
+	assert.Equal(t, err2, ErrAlreadyOwnLock)
 }
 
 func TestUnlock(t *testing.T) {

--- a/cluster/zookeeper/locks.go
+++ b/cluster/zookeeper/locks.go
@@ -15,6 +15,9 @@ type LockEntries struct {
 
 // locks returns a LockEntries of all current locks.
 func (z *ZooKeeperLock) locks() (LockEntries, error) {
+	z.mu.RLock()
+	defer z.mu.RUnlock()
+
 	var locks = LockEntries{
 		m: map[int]string{},
 		l: []int{},

--- a/cluster/zookeeper/zookeeper-example/main.go
+++ b/cluster/zookeeper/zookeeper-example/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	timeout := flag.Duration("timeout", 3*time.Second, "lock wait timeout")
+	owner := flag.String("owner", "user1", "the lock owner ID")
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)
@@ -21,12 +22,13 @@ func main() {
 
 	// Init a Lock.
 	cfg := zklocking.ZooKeeperLockConfig{
-		Address: "localhost:2181",
-		Path:    "/my/locks",
+		Address:  "localhost:2181",
+		Path:     "/my/locks",
+		OwnerKey: "owner",
 	}
 
 	lock, _ := zklocking.NewZooKeeperLock(cfg)
-	ctx, c := context.WithTimeout(context.Background(), *timeout)
+	ctx, c := context.WithTimeout(context.WithValue(context.Background(), "owner", *owner), *timeout)
 	defer c()
 
 	// Try the lock.
@@ -34,9 +36,9 @@ func main() {
 		log.Println(err)
 	} else {
 		log.Println("I've got the lock!")
+		defer log.Println("I've released the lock")
+		defer lock.Unlock(ctx)
 	}
 
 	<-sigs
-	lock.Unlock(ctx)
-	log.Println("I've released the lock")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,8 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
-      - "8090:8090"
+      - "8080"
+      - "8090"
     depends_on:
       - zookeeper
       - kafka

--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -156,11 +156,6 @@ func (s *Server) CreateTopic(ctx context.Context, req *pb.CreateTopicRequest) (*
 		defer cancel()
 	}
 
-	if err := s.Locking.Lock(ctx); err != nil {
-		return nil, err
-	}
-	defer s.Locking.Unlock(ctx)
-
 	if req.Topic == nil {
 		return nil, ErrTopicFieldMissing
 	}
@@ -180,6 +175,11 @@ func (s *Server) CreateTopic(ctx context.Context, req *pb.CreateTopicRequest) (*
 	if len(resp.Names) > 0 {
 		return empty, ErrTopicAlreadyExists
 	}
+
+	if err := s.Locking.Lock(ctx); err != nil {
+		return nil, err
+	}
+	defer s.Locking.Unlock(ctx)
 
 	// If we're targeting a specific set of brokers by tag, build
 	// a replica assignment.

--- a/registry/server/server.go
+++ b/registry/server/server.go
@@ -427,10 +427,6 @@ func (s *Server) LogRequest(ctx context.Context, params string, reqID uint64) {
 
 type dummyLock struct{}
 
-func (dl dummyLock) Lock(_ context.Context) error {
-	return nil
-}
-
-func (dl dummyLock) Unlock(_ context.Context) error {
-	return nil
-}
+func (dl dummyLock) Lock(_ context.Context) error   { return nil }
+func (dl dummyLock) Unlock(_ context.Context) error { return nil }
+func (dl dummyLock) Owner() interface{}             { return nil }


### PR DESCRIPTION
This is a locking bugfix PR for two scenarios:

1) When multiple requestors with a shared `ZooKeeperLock` are contending, the local mutex deadlocks. This removes the deadlock and also adds finer grained RW locking.
2) When `CreateTopic` is called with optional topic tags, a child `TagTopics` request is called. When `TagTopics` returns, it inadvertently unlocks the parent `CreateTopic` lock. `TagTopics` is now aware whether it's being called directly or via `CreateTopic` and handles unlocking accordingly.

Also reorders the docker build to make more optimal use of layers for repeat build efficiency.