### PR TITLE
don't parse empty string

### DIFF
--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -110,7 +110,10 @@ func rebuild(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	evacBrokers := brokerStringToSlice(leb)
+	var evacBrokers []int
+	if leb != "" {
+		evacBrokers = brokerStringToSlice(leb)
+	}
 
 	// General flow:
 	// 1) A PartitionMap is formed (either unmarshaled from the literal


### PR DESCRIPTION
Avoids parsing an empty string when an optional feature flag is not specified.