### PR TITLE
Topicmappr refactor

### DIFF
--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -23,32 +23,13 @@ const (
 var (
 	// Characters allowed in Kafka topic names
 	topicNormalChar = regexp.MustCompile(`[a-zA-Z0-9_\\-]`)
-
-	// Config holds global configs.
-	Config struct {
-		topics        []*regexp.Regexp
-		topicsExclude []*regexp.Regexp
-		brokers       []int
-	}
 )
 
-func bootstrap(cmd *cobra.Command) {
-	b, _ := cmd.Flags().GetString("brokers")
-	Config.brokers = brokerStringToSlice(b)
-
+func sanitizeInput(cmd *cobra.Command) {
 	// Append trailing slash if not included.
 	op := cmd.Flag("out-path").Value.String()
 	if op != "" && !strings.HasSuffix(op, "/") {
 		cmd.Flags().Set("out-path", op+"/")
-	}
-
-	// Populate topic include / exclude regex.
-	if include, _ := cmd.Flags().GetString("topics"); include != "" {
-		Config.topics = topicRegex(include)
-	}
-
-	if exclude, _ := cmd.Flags().GetString("topics-exclude"); exclude != "" {
-		Config.topicsExclude = topicRegex(exclude)
 	}
 }
 

--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -44,18 +44,18 @@ func bootstrap(cmd *cobra.Command) {
 
 	// Populate topic include / exclude regex.
 	if include, _ := cmd.Flags().GetString("topics"); include != "" {
-		Config.topics = TopicRegex(include)
+		Config.topics = topicRegex(include)
 	}
 
 	if exclude, _ := cmd.Flags().GetString("topics-exclude"); exclude != "" {
-		Config.topicsExclude = TopicRegex(exclude)
+		Config.topicsExclude = topicRegex(exclude)
 	}
 }
 
-// TopicRegex takes a string of csv values and returns a []*regexp.Regexp.
+// topicRegex takes a string of csv values and returns a []*regexp.Regexp.
 // The values are either a string literal and become ^value$ or are regex and
 // compiled then added.
-func TopicRegex(s string) []*regexp.Regexp {
+func topicRegex(s string) []*regexp.Regexp {
 	var out []*regexp.Regexp
 
 	// Update string literals to ^value$ regex.

--- a/cmd/topicmappr/commands/config.go
+++ b/cmd/topicmappr/commands/config.go
@@ -88,23 +88,21 @@ func topicRegex(s string) []*regexp.Regexp {
 //    topic discovery` via ZooKeeper.
 //  - that the --placement flag was set to 'storage', which expects
 //    metrics metadata to be stored in ZooKeeper.
-func initZooKeeper(cmd *cobra.Command) (kafkazk.Handler, error) {
+func initZooKeeper(zkAddr, kafkaPrefix, metricsPrefix string) (kafkazk.Handler, error) {
 	// Suppress underlying ZK client noise.
 	log.SetOutput(ioutil.Discard)
 
-	zkAddr := cmd.Parent().Flag("zk-addr").Value.String()
-	timeout := 250 * time.Millisecond
-
 	zk, err := kafkazk.NewHandler(&kafkazk.Config{
 		Connect:       zkAddr,
-		Prefix:        cmd.Parent().Flag("zk-prefix").Value.String(),
-		MetricsPrefix: cmd.Flag("zk-metrics-prefix").Value.String(),
+		Prefix:        kafkaPrefix,
+		MetricsPrefix: metricsPrefix,
 	})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error connecting to ZooKeeper: %s", err)
 	}
 
+	timeout := 250 * time.Millisecond
 	time.Sleep(timeout)
 
 	if !zk.Ready() {

--- a/cmd/topicmappr/commands/evac_leadership_test.go
+++ b/cmd/topicmappr/commands/evac_leadership_test.go
@@ -41,7 +41,7 @@ var pMapIn = kafkazk.PartitionMap{
 func TestRemoveProblemBroker(t *testing.T) {
 	problemBrokerId := 10001
 
-	pMapOut := EvacLeadership(pMapIn, []int{problemBrokerId}, []string{topic})
+	pMapOut := evacuateLeadership(pMapIn, []int{problemBrokerId}, []string{topic})
 
 	for _, partition := range pMapOut.Partitions {
 		if partition.Replicas[0] == problemBrokerId {
@@ -53,7 +53,7 @@ func TestRemoveProblemBroker(t *testing.T) {
 func TestEvacTwoProblemBrokers(t *testing.T) {
 	problemBrokers := []int{10001, 10002}
 
-	pMapOut := EvacLeadership(pMapIn, problemBrokers, []string{topic})
+	pMapOut := evacuateLeadership(pMapIn, problemBrokers, []string{topic})
 
 	for _, partition := range pMapOut.Partitions {
 		if partition.Replicas[0] == problemBrokers[0] || partition.Replicas[0] == problemBrokers[1] {
@@ -63,7 +63,7 @@ func TestEvacTwoProblemBrokers(t *testing.T) {
 }
 
 func TestNoMatchingTopicToEvac(t *testing.T) {
-	pMapOut := EvacLeadership(pMapIn, []int{10001}, []string{"some other topic"})
+	pMapOut := evacuateLeadership(pMapIn, []int{10001}, []string{"some other topic"})
 
 	for i, partition := range pMapOut.Partitions {
 		for j, broker := range partition.Replicas {
@@ -81,7 +81,7 @@ func TestNoMatchingTopicToEvac(t *testing.T) {
 //	problemBrokers[10002] = &kafkazk.Broker{}
 //	problemBrokers[10003] = &kafkazk.Broker{}
 //
-//	EvacLeadership(pMapIn, problemBrokers)
+//	evacuateLeadership(pMapIn, problemBrokers)
 //
-//	t.Errorf("EvacLeadership should have errored out at this point.")
+//	t.Errorf("evacuateLeadership should have errored out at this point.")
 //}

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -23,7 +23,6 @@ func (e errors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
 // referenced in the map.
 func printTopics(pm *kafkazk.PartitionMap) {
 	topics := pm.Topics()
-	sort.Strings(topics)
 
 	fmt.Printf("\nTopics:\n")
 	for _, t := range topics {

--- a/cmd/topicmappr/commands/output.go
+++ b/cmd/topicmappr/commands/output.go
@@ -200,7 +200,7 @@ func skipReassignmentNoOps(pm1, pm2 *kafkazk.PartitionMap) (*kafkazk.PartitionMa
 }
 
 // writeMaps takes a PartitionMap and writes out files.
-func writeMaps(cmd *cobra.Command, pm *kafkazk.PartitionMap, phasedPM *kafkazk.PartitionMap) {
+func writeMaps(outPath, outFile string, pm *kafkazk.PartitionMap, phasedPM *kafkazk.PartitionMap) {
 	if len(pm.Partitions) == 0 {
 		fmt.Println("\nNo partition reassignments, skipping map generation")
 		return
@@ -212,9 +212,6 @@ func writeMaps(cmd *cobra.Command, pm *kafkazk.PartitionMap, phasedPM *kafkazk.P
 		phaseSuffix[0] = "-phase1"
 		phaseSuffix[1] = "-phase2"
 	}
-
-	outPath := cmd.Flag("out-path").Value.String()
-	outFile := cmd.Flag("out-file").Value.String()
 
 	// Break map up by topic.
 	tm := map[string]*kafkazk.PartitionMap{}

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"os"
 	"sync"
 
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
@@ -130,58 +128,4 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 	close(results)
 
 	return results
-}
-
-// EvacLeadership For the given set of topics, makes sure that the given brokers are not
-// leaders of any partitions. If we have any partitions that only have replicas from the
-// evac broker list, we will fail.
-func EvacLeadership(partitionMapIn kafkazk.PartitionMap, evacBrokers []int, evacTopics []string) *kafkazk.PartitionMap {
-	// evacuation algo starts here
-	partitionMapOut := partitionMapIn.Copy()
-
-	// make a lookup map of topics
-	topicsMap := map[string]struct{}{}
-	for _, topic := range evacTopics {
-		topicsMap[topic] = struct{}{}
-	}
-
-	// make a lookup map of topics
-	brokersMap := map[int]struct{}{}
-	for _, b := range evacBrokers {
-		brokersMap[b] = struct{}{}
-	}
-
-	// TODO What if we only want to evacuate a subset of partitions?
-	// For now, problem brokers is the bigger use case.
-
-	// swap leadership for all broker/partition/topic combos
-	for i, p := range partitionMapIn.Partitions {
-		// check the topic is one of the target topics
-		if _, correctTopic := topicsMap[p.Topic]; !correctTopic {
-			continue
-		}
-
-		// check the leader to see if its one of the evac brokers
-		if _, contains := brokersMap[p.Replicas[0]]; !contains {
-			continue
-		}
-
-		for j, replica := range p.Replicas {
-			// If one of the replicas is not being leadership evacuated, use that one and swap.
-			if _, contains := brokersMap[replica]; !contains {
-				newLeader := p.Replicas[j]
-				partitionMapOut.Partitions[i].Replicas[j] = p.Replicas[0]
-				partitionMapOut.Partitions[i].Replicas[0] = newLeader
-				break
-			}
-
-			// If we've tried every replica, but they are all being leader evac'd.
-			if replica == p.Replicas[len(p.Replicas)-1] {
-				fmt.Println("No replicas available to evacuate leadership to. All replicas present in EvacLeadership broker list.")
-				os.Exit(1)
-			}
-		}
-	}
-
-	return partitionMapOut
 }

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -1,9 +1,15 @@
 package commands
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
 	"sync"
 
 	"github.com/DataDog/kafka-kit/v3/kafkazk"
+	"github.com/spf13/cobra"
 )
 
 // reassignmentBundle holds a reassignment PartitionMap along with some input
@@ -24,16 +30,164 @@ type reassignmentBundle struct {
 	brokers kafkazk.BrokerMap
 }
 
-type computeReassignmentBundlesParams struct {
-	offloadTargets         []int
-	tolerance              float64
-	partitionMap           *kafkazk.PartitionMap
-	partitionMeta          kafkazk.PartitionMetaMap
-	brokerMap              kafkazk.BrokerMap
+type reassignParams struct {
+	brokers                []int
+	localityScoped         bool
+	maxMetadataAge         int
+	optimizeLeadership     bool
 	partitionLimit         int
 	partitionSizeThreshold int
-	localityScoped         bool
+	storageThreshold       float64
+	storageThresholdGB     float64
+	tolerance              float64
+	topics                 []*regexp.Regexp
+	topicsExclude          []*regexp.Regexp
+	requireNewBrokers      bool
 	verbose                bool
+}
+
+func (s reassignParams) UseFixedTolerance() bool { return s.tolerance != 0.00 }
+
+func reassignParamsFromCmd(cmd *cobra.Command) (params reassignParams) {
+	brokers, _ := cmd.Flags().GetString("brokers")
+	params.brokers = brokerStringToSlice(brokers)
+	localityScoped, _ := cmd.Flags().GetBool("locality-scoped")
+	params.localityScoped = localityScoped
+	maxMetadataAge, _ := cmd.Flags().GetInt("metrics-age")
+	params.maxMetadataAge = maxMetadataAge
+	optimizeLeadership, _ := cmd.Flags().GetBool("optimize-leadership")
+	params.optimizeLeadership = optimizeLeadership
+	partitionLimit, _ := cmd.Flags().GetInt("partition-limit")
+	params.partitionLimit = partitionLimit
+	partitionSizeThreshold, _ := cmd.Flags().GetInt("partition-size-threshold")
+	params.partitionSizeThreshold = partitionSizeThreshold
+	storageThreshold, _ := cmd.Flags().GetFloat64("storage-threshold")
+	params.storageThreshold = storageThreshold
+	storageThresholdGB, _ := cmd.Flags().GetFloat64("storage-threshold-gb")
+	params.storageThresholdGB = storageThresholdGB
+	tolerance, _ := cmd.Flags().GetFloat64("tolerance")
+	params.tolerance = tolerance
+	topics, _ := cmd.Flags().GetString("topics")
+	params.topics = topicRegex(topics)
+	topicsExclude, _ := cmd.Flags().GetString("topics-exclude")
+	params.topicsExclude = topicRegex(topicsExclude)
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	params.verbose = verbose
+	return params
+}
+
+func reassign(params reassignParams, zk kafkazk.Handler) (*kafkazk.PartitionMap, []error) {
+	// Get broker and partition metadata.
+	if err := checkMetaAge(zk, params.maxMetadataAge); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	brokerMeta, errs := getBrokerMeta(zk, true)
+	if errs != nil && brokerMeta == nil {
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		os.Exit(1)
+	}
+	partitionMeta, err := getPartitionMeta(zk)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Get the current partition map.
+	partitionMapIn, err := kafkazk.PartitionMapFromZK(params.topics, zk)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Exclude any topics that are pending deletion.
+	pending, err := stripPendingDeletes(partitionMapIn, zk)
+	if err != nil {
+		fmt.Println("Error fetching topics pending deletion")
+	}
+
+	// Exclude any explicit exclusions.
+	excluded := removeTopics(partitionMapIn, params.topicsExclude)
+
+	// Print topics matched to input params.
+	printTopics(partitionMapIn)
+
+	// Print if any topics were excluded due to pending deletion.
+	printExcludedTopics(pending, excluded)
+
+	// Get a broker map.
+	brokersIn := kafkazk.BrokerMapFromPartitionMap(partitionMapIn, brokerMeta, false)
+
+	// Validate all broker params, get a copy of the broker IDs targeted for
+	// partition offloading.
+	if errs := validateBrokers(params.brokers, brokersIn, brokerMeta, params.requireNewBrokers); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		os.Exit(1)
+	}
+
+	// Get offload targets.
+	offloadTargets := determineOffloadTargets(params, brokersIn)
+
+	// Sort offloadTargets by storage free ascending.
+	sort.Sort(offloadTargetsBySize{t: offloadTargets, bm: brokersIn})
+
+	// Generate reassignmentBundles for a rebalance.
+	results := computeReassignmentBundles(
+		params,
+		partitionMapIn,
+		partitionMeta,
+		brokersIn,
+		offloadTargets,
+	)
+
+	// Merge all results into a slice.
+	resultsByRange := []reassignmentBundle{}
+	for r := range results {
+		resultsByRange = append(resultsByRange, r)
+	}
+
+	// Sort the rebalance results by range ascending.
+	sort.Slice(resultsByRange, func(i, j int) bool {
+		switch {
+		case resultsByRange[i].storageRange < resultsByRange[j].storageRange:
+			return true
+		case resultsByRange[i].storageRange > resultsByRange[j].storageRange:
+			return false
+		}
+
+		return resultsByRange[i].stdDev < resultsByRange[j].stdDev
+	})
+
+	// Chose the results with the lowest range.
+	m := resultsByRange[0]
+	partitionMapOut, brokersOut, relos := m.partitionMap, m.brokers, m.relocations
+
+	// Print parameters used for rebalance decisions.
+	printReassignmentParams(params, resultsByRange, brokersIn, m.tolerance)
+
+	// Optimize leaders.
+	if params.optimizeLeadership {
+		partitionMapOut.OptimizeLeaderFollower()
+	}
+
+	// Print planned relocations.
+	printPlannedRelocations(offloadTargets, relos, partitionMeta)
+
+	// Print map change results.
+	printMapChanges(partitionMapIn, partitionMapOut)
+
+	// Print broker assignment statistics.
+	errs = printBrokerAssignmentStats(partitionMapIn, partitionMapOut, brokersIn, brokersOut, true, 1.0)
+
+	// Ignore no-ops; rebalances will naturally have a high percentage of these.
+	partitionMapIn, partitionMapOut = skipReassignmentNoOps(partitionMapIn, partitionMapOut)
+
+	return partitionMapOut, errs
+
 }
 
 // computeReassignmentBundles takes computeReassignmentBundlesParams and returns
@@ -41,9 +195,15 @@ type computeReassignmentBundlesParams struct {
 // if a fixed computeReassignmentBundlesParams.tolerance value (non 0.00) is
 // specified, otherwise it will contain a series of reassignmentBundle for multiple
 // interval values. When generating a series, the results are computed in parallel.
-func computeReassignmentBundles(params computeReassignmentBundlesParams) chan reassignmentBundle {
+func computeReassignmentBundles(
+	params reassignParams,
+	partitionMap *kafkazk.PartitionMap,
+	partitionMeta kafkazk.PartitionMetaMap,
+	brokerMap kafkazk.BrokerMap,
+	offloadTargets []int,
+) chan reassignmentBundle {
 	otm := map[int]struct{}{}
-	for _, id := range params.offloadTargets {
+	for _, id := range offloadTargets {
 		otm[id] = struct{}{}
 	}
 
@@ -55,13 +215,11 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 		// Whether we're using a fixed tolerance (non 0.00 value) set via flag or
 		// interval values.
 		var tol float64
-		var fixedTolerance bool
 
-		if params.tolerance == 0.00 {
-			tol = i
-		} else {
+		if params.UseFixedTolerance() {
 			tol = params.tolerance
-			fixedTolerance = true
+		} else {
+			tol = i
 		}
 
 		wg.Add(1)
@@ -69,14 +227,14 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 		go func() {
 			defer wg.Done()
 
-			partitionMap := params.partitionMap.Copy()
+			partitionMap := partitionMap.Copy()
 
 			// Bundle planRelocationsForBrokerParams.
 			relocationParams := planRelocationsForBrokerParams{
 				relos:                  map[int][]relocation{},
 				mappings:               partitionMap.Mappings(),
-				brokers:                params.brokerMap.Copy(),
-				partitionMeta:          params.partitionMeta,
+				brokers:                brokerMap.Copy(),
+				partitionMeta:          partitionMeta,
 				plan:                   relocationPlan{},
 				topPartitionsLimit:     params.partitionLimit,
 				partitionSizeThreshold: params.partitionSizeThreshold,
@@ -88,9 +246,9 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 
 			// Iterate over offload targets, planning at most one relocation per iteration.
 			// Continue this loop until no more relocations can be planned.
-			for exhaustedCount := 0; exhaustedCount < len(params.offloadTargets); {
+			for exhaustedCount := 0; exhaustedCount < len(offloadTargets); {
 				relocationParams.pass++
-				for _, sourceID := range params.offloadTargets {
+				for _, sourceID := range offloadTargets {
 					// Update the source broker ID
 					relocationParams.sourceID = sourceID
 
@@ -119,7 +277,7 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 		}()
 
 		// Break early if we're using a fixed tolerance value.
-		if fixedTolerance {
+		if params.UseFixedTolerance() {
 			break
 		}
 	}
@@ -128,4 +286,82 @@ func computeReassignmentBundles(params computeReassignmentBundlesParams) chan re
 	close(results)
 
 	return results
+}
+
+func validateBrokers(
+	newBrokers []int,
+	currentBrokers kafkazk.BrokerMap,
+	bm kafkazk.BrokerMetaMap,
+	newBrokersRequired bool,
+) []error {
+	// No broker changes are permitted in rebalance other than new broker additions.
+	fmt.Println("\nValidating broker list:")
+
+	// Update the current BrokerList with
+	// the provided broker list.
+	c, msgs := currentBrokers.Update(newBrokers, bm)
+	for m := range msgs {
+		fmt.Printf("%s%s\n", indent, m)
+	}
+
+	if c.Changes() {
+		fmt.Printf("%s-\n", indent)
+	}
+
+	// Check if any referenced brokers are marked as having missing/partial metrics data.
+	if errs := ensureBrokerMetrics(currentBrokers, bm); len(errs) > 0 {
+		return errs
+	}
+
+	switch {
+	case c.Missing > 0, c.OldMissing > 0, c.Replace > 0:
+		return []error{fmt.Errorf("reassignment only allows broker additions")}
+	case c.New > 0:
+		fmt.Printf("%s%d additional brokers added\n", indent, c.New)
+		fmt.Printf("%s-\n", indent)
+		fmt.Printf("%sOK\n", indent)
+	case newBrokersRequired:
+		return []error{fmt.Errorf("reassignment requires additional brokers\n")}
+
+	}
+	return nil
+}
+
+func determineOffloadTargets(params reassignParams, brokers kafkazk.BrokerMap) []int {
+	var offloadTargets []int
+
+	var selectorMethod bytes.Buffer
+	selectorMethod.WriteString("Brokers targeted for partition offloading ")
+
+	// Switch on the target selection method. If a storage threshold in gigabytes
+	// is specified, prefer this. Otherwise, use the percentage below mean threshold.
+	var f kafkazk.BrokerFilterFn
+	if params.storageThresholdGB > 0.00 {
+		selectorMethod.WriteString(fmt.Sprintf("(< %.2fGB storage free)", params.storageThresholdGB))
+
+		// Get all non-new brokers with a StorageFree below the storage threshold in GB.
+		f = func(b *kafkazk.Broker) bool {
+			if !b.New && b.StorageFree < params.storageThresholdGB*div {
+				return true
+			}
+			return false
+		}
+
+	} else if params.storageThreshold > 0.00 {
+		// Find brokers where the storage free is t % below the harmonic mean.
+		selectorMethod.WriteString(fmt.Sprintf("(>= %.2f%% threshold below hmean)", params.storageThreshold*100))
+		f = kafkazk.BelowMeanFn(params.storageThreshold, brokers.HMean)
+	} else {
+		// Specifying 0 targets all non-new brokers, this is a scale up
+		f = func(b *kafkazk.Broker) bool { return !b.New }
+	}
+
+	matches := brokers.Filter(f)
+	for _, b := range matches {
+		offloadTargets = append(offloadTargets, b.ID)
+	}
+
+	fmt.Printf("\n%s:\n", selectorMethod.String())
+
+	return offloadTargets
 }

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -76,7 +76,7 @@ func reassignParamsFromCmd(cmd *cobra.Command) (params reassignParams) {
 	return params
 }
 
-func reassign(params reassignParams, zk kafkazk.Handler) (*kafkazk.PartitionMap, []error) {
+func reassign(params reassignParams, zk kafkazk.Handler) ([]*kafkazk.PartitionMap, []error) {
 	// Get broker and partition metadata.
 	if err := checkMetaAge(zk, params.maxMetadataAge); err != nil {
 		fmt.Println(err)
@@ -186,7 +186,7 @@ func reassign(params reassignParams, zk kafkazk.Handler) (*kafkazk.PartitionMap,
 	// Ignore no-ops; rebalances will naturally have a high percentage of these.
 	partitionMapIn, partitionMapOut = skipReassignmentNoOps(partitionMapIn, partitionMapOut)
 
-	return partitionMapOut, errs
+	return []*kafkazk.PartitionMap{partitionMapOut}, errs
 
 }
 

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -53,10 +53,12 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	defer zk.Close()
 
+	maxMetadataAge, _ := cmd.Flags().GetInt("metrics-age")
+
 	// Get broker and partition metadata.
-	checkMetaAge(cmd, zk)
-	brokerMeta := getBrokerMeta(cmd, zk, true)
-	partitionMeta := getPartitionMeta(cmd, zk)
+	checkMetaAge(zk, maxMetadataAge)
+	brokerMeta := getBrokerMeta(zk, true)
+	partitionMeta := getPartitionMeta(zk)
 
 	// Get the current partition map.
 	partitionMapIn, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
@@ -174,7 +176,7 @@ func validateBrokersForRebalance(cmd *cobra.Command, brokers kafkazk.BrokerMap, 
 	}
 
 	// Check if any referenced brokers are marked as having missing/partial metrics data.
-	ensureBrokerMetrics(cmd, brokers, bm)
+	ensureBrokerMetrics(brokers, bm)
 
 	switch {
 	case c.Missing > 0, c.OldMissing > 0, c.Replace > 0:

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -86,7 +86,7 @@ func rebalanceParamsFromCmd(cmd *cobra.Command) (params rebalanceParams) {
 }
 
 func rebalance(cmd *cobra.Command, _ []string) {
-	bootstrap(cmd)
+	sanitizeInput(cmd)
 	params := rebalanceParamsFromCmd(cmd)
 
 	// ZooKeeper init.
@@ -120,7 +120,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	}
 
 	// Get the current partition map.
-	partitionMapIn, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
+	partitionMapIn, err := kafkazk.PartitionMapFromZK(params.topics, zk)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -133,7 +133,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	}
 
 	// Exclude any explicit exclusions.
-	excluded := removeTopics(partitionMapIn, Config.topicsExclude)
+	excluded := removeTopics(partitionMapIn, params.topicsExclude)
 
 	// Print topics matched to input params.
 	printTopics(partitionMapIn)
@@ -224,7 +224,7 @@ func validateBrokersForRebalance(params rebalanceParams, brokers kafkazk.BrokerM
 
 	// Update the current BrokerList with
 	// the provided broker list.
-	c, msgs := brokers.Update(Config.brokers, bm)
+	c, msgs := brokers.Update(params.brokers, bm)
 	for m := range msgs {
 		fmt.Printf("%s%s\n", indent, m)
 	}

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -54,7 +54,7 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	defer zk.Close()
 
-	partitionMap, errs := reassign(params, zk)
+	partitionMaps, errs := reassign(params, zk)
 
 	// Handle errors that are possible to be overridden by the user (aka 'WARN'
 	// in topicmappr console output).
@@ -63,5 +63,5 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	// Write maps.
 	outPath := cmd.Flag("out-path").Value.String()
 	outFile := cmd.Flag("out-file").Value.String()
-	writeMaps(outPath, outFile, partitionMap, nil)
+	writeMaps(outPath, outFile, partitionMaps)
 }

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -33,7 +33,6 @@ func init() {
 	rebalanceCmd.Flags().Int("partition-size-threshold", 512, "Size in megabytes where partitions below this value will not be moved in a rebalance")
 	rebalanceCmd.Flags().Bool("locality-scoped", false, "Ensure that all partition movements are scoped by rack.id")
 	rebalanceCmd.Flags().Bool("verbose", false, "Verbose output")
-	rebalanceCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
 	rebalanceCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes)")
 	rebalanceCmd.Flags().Bool("optimize-leadership", false, "Rebalance all broker leader/follower ratios")
 

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -45,7 +45,10 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	bootstrap(cmd)
 
 	// ZooKeeper init.
-	zk, err := initZooKeeper(cmd)
+	zkAddr := cmd.Parent().Flag("zk-addr").Value.String()
+	kafkaPrefix := cmd.Parent().Flag("zk-prefix").Value.String()
+	metricsPrefix := cmd.Flag("zk-metrics-prefix").Value.String()
+	zk, err := initZooKeeper(zkAddr, kafkaPrefix, metricsPrefix)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -175,7 +175,9 @@ func rebalance(cmd *cobra.Command, _ []string) {
 	partitionMapIn, partitionMapOut = skipReassignmentNoOps(partitionMapIn, partitionMapOut)
 
 	// Write maps.
-	writeMaps(cmd, partitionMapOut, nil)
+	outPath := cmd.Flag("out-path").Value.String()
+	outFile := cmd.Flag("out-file").Value.String()
+	writeMaps(outPath, outFile, partitionMapOut, nil)
 }
 
 func validateBrokersForRebalance(cmd *cobra.Command, brokers kafkazk.BrokerMap, bm kafkazk.BrokerMetaMap) []int {

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -307,5 +307,5 @@ func rebuild(cmd *cobra.Command, _ []string) {
 
 	outPath := cmd.Flag("out-path").Value.String()
 	outFile := cmd.Flag("out-file").Value.String()
-	writeMaps(outPath, outFile, partitionMapOut, phasedMap)
+	writeMaps(outPath, outFile, []*kafkazk.PartitionMap{phasedMap, partitionMapOut})
 }

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -292,7 +292,10 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	printMapChanges(originalMap, partitionMapOut)
 
 	// Print broker assignment statistics.
-	printBrokerAssignmentStats(cmd, originalMap, partitionMapOut, brokersOrig, brokers)
+	errs = append(
+		errs,
+		printBrokerAssignmentStats(originalMap, partitionMapOut, brokersOrig, brokers, params.placement == "storage", params.partitionSizeFactor)...,
+	)
 
 	// Print error/warnings.
 	handleOverridableErrs(cmd, errs)

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -90,7 +90,10 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	var zk kafkazk.Handler
 	if m || len(Config.topics) > 0 || p == "storage" {
 		var err error
-		zk, err = initZooKeeper(cmd)
+		zkAddr := cmd.Parent().Flag("zk-addr").Value.String()
+		kafkaPrefix := cmd.Parent().Flag("zk-prefix").Value.String()
+		metricsPrefix := cmd.Flag("zk-metrics-prefix").Value.String()
+		zk, err = initZooKeeper(zkAddr, kafkaPrefix, metricsPrefix)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -38,7 +38,6 @@ func init() {
 	rebuildCmd.Flags().String("optimize", "distribution", "Optimization priority for the storage placement strategy: [distribution, storage]")
 	rebuildCmd.Flags().Float64("partition-size-factor", 1.0, "Factor by which to multiply partition sizes when using storage placement")
 	rebuildCmd.Flags().String("brokers", "", "Broker list to scope all partition placements to ('-1' for all currently mapped brokers, '-2' for all brokers in cluster)")
-	rebuildCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics (when using storage placement)")
 	rebuildCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes) (when using storage placement)")
 	rebuildCmd.Flags().Bool("skip-no-ops", false, "Skip no-op partition assigments")
 	rebuildCmd.Flags().Bool("optimize-leadership", false, "Rebalance all broker leader/follower ratios")

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -212,7 +212,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 		phasedMap = phasedReassignment(originalMap, partitionMapOut)
 	}
 
-	partitionMapOut = EvacLeadership(*partitionMapOut, evacBrokers, evacTopics)
+	partitionMapOut = evacuateLeadership(*partitionMapOut, evacBrokers, evacTopics)
 
 	// Print map change results.
 	printMapChanges(originalMap, partitionMapOut)

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -136,8 +136,9 @@ func (c rebuildParams) validate() error {
 }
 
 func rebuild(cmd *cobra.Command, _ []string) {
-	bootstrap(cmd)
+	sanitizeInput(cmd)
 	params := rebuildParamsFromCmd(cmd)
+
 	err := params.validate()
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -103,7 +103,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	var evacTopics []string
 	var err error
 	if let != "" {
-		evacTopics, err = zk.GetTopics(TopicRegex(let))
+		evacTopics, err = zk.GetTopics(topicRegex(let))
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -131,19 +131,20 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	// Fetch broker metadata.
 	var withMetrics bool
 	if cmd.Flag("placement").Value.String() == "storage" {
-		checkMetaAge(cmd, zk)
+		maxMetadataAge, _ := cmd.Flags().GetInt("metrics-age")
+		checkMetaAge(zk, maxMetadataAge)
 		withMetrics = true
 	}
 
 	var brokerMeta kafkazk.BrokerMetaMap
 	if m, _ := cmd.Flags().GetBool("use-meta"); m {
-		brokerMeta = getBrokerMeta(cmd, zk, withMetrics)
+		brokerMeta = getBrokerMeta(zk, withMetrics)
 	}
 
 	// Fetch partition metadata.
 	var partitionMeta kafkazk.PartitionMetaMap
 	if cmd.Flag("placement").Value.String() == "storage" {
-		partitionMeta = getPartitionMeta(cmd, zk)
+		partitionMeta = getPartitionMeta(zk)
 	}
 
 	// Build a partition map either from literal map text input or by fetching the
@@ -168,7 +169,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 	// Check if any referenced brokers are marked as having
 	// missing/partial metrics data.
 	if m, _ := cmd.Flags().GetBool("use-meta"); m {
-		ensureBrokerMetrics(cmd, brokers, brokerMeta)
+		ensureBrokerMetrics(brokers, brokerMeta)
 	}
 
 	// Create substitution affinities.

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -248,5 +248,7 @@ func rebuild(cmd *cobra.Command, _ []string) {
 		originalMap, partitionMapOut = skipReassignmentNoOps(originalMap, partitionMapOut)
 	}
 
-	writeMaps(cmd, partitionMapOut, phasedMap)
+	outPath := cmd.Flag("out-path").Value.String()
+	outFile := cmd.Flag("out-file").Value.String()
+	writeMaps(outPath, outFile, partitionMapOut, phasedMap)
 }

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -217,8 +217,7 @@ func buildMap(cmd *cobra.Command, pm *kafkazk.PartitionMap, pmm kafkazk.Partitio
 		// If the storage placement strategy is being used,
 		// update the broker StorageFree values.
 		if placement == "storage" {
-			allBrokers := func(b *kafkazk.Broker) bool { return true }
-			err := rebuildParams.BM.SubStorage(pm, pmm, allBrokers)
+			err := rebuildParams.BM.SubStorage(pm, pmm, kafkazk.AllBrokersFn)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -231,8 +230,7 @@ func buildMap(cmd *cobra.Command, pm *kafkazk.PartitionMap, pmm kafkazk.Partitio
 
 	// Update the StorageFree only on brokers marked for replacement.
 	if placement == "storage" {
-		replacedBrokers := func(b *kafkazk.Broker) bool { return b.Replace }
-		err := rebuildParams.BM.SubStorage(pm, pmm, replacedBrokers)
+		err := rebuildParams.BM.SubStorage(pm, pmm, kafkazk.ReplacedBrokersFn)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -44,7 +44,10 @@ func getPartitionMap(cmd *cobra.Command, zk kafkazk.Handler) (*kafkazk.Partition
 		}
 
 		// Exclude any topics that are pending deletion.
-		pd := stripPendingDeletes(pm, zk)
+		pd, err := stripPendingDeletes(pm, zk)
+		if err != nil {
+			fmt.Println("Error fetching topics pending deletion")
+		}
 
 		// Exclude topics explicitly listed.
 		et := removeTopics(pm, Config.topicsExclude)

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -330,7 +330,7 @@ func evacuateLeadership(partitionMapIn kafkazk.PartitionMap, evacBrokers []int, 
 
 			// If we've tried every replica, but they are all being leader evac'd.
 			if replica == p.Replicas[len(p.Replicas)-1] {
-				fmt.Println("No replicas available to evacuate leadership to. All replicas present in EvacLeadership broker list.")
+				fmt.Println("[ERROR] trying to evict all replicas at once")
 				os.Exit(1)
 			}
 		}

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -284,3 +284,57 @@ func notInReplicaSet(id int, rs []int) bool {
 
 	return true
 }
+
+// evacuateLeadership For the given set of topics, makes sure that the given brokers are not
+// leaders of any partitions. If we have any partitions that only have replicas from the
+// evac broker list, we will fail.
+func evacuateLeadership(partitionMapIn kafkazk.PartitionMap, evacBrokers []int, evacTopics []string) *kafkazk.PartitionMap {
+	// evacuation algo starts here
+	partitionMapOut := partitionMapIn.Copy()
+
+	// make a lookup map of topics
+	topicsMap := map[string]struct{}{}
+	for _, topic := range evacTopics {
+		topicsMap[topic] = struct{}{}
+	}
+
+	// make a lookup map of topics
+	brokersMap := map[int]struct{}{}
+	for _, b := range evacBrokers {
+		brokersMap[b] = struct{}{}
+	}
+
+	// TODO What if we only want to evacuate a subset of partitions?
+	// For now, problem brokers is the bigger use case.
+
+	// swap leadership for all broker/partition/topic combos
+	for i, p := range partitionMapIn.Partitions {
+		// check the topic is one of the target topics
+		if _, correctTopic := topicsMap[p.Topic]; !correctTopic {
+			continue
+		}
+
+		// check the leader to see if its one of the evac brokers
+		if _, contains := brokersMap[p.Replicas[0]]; !contains {
+			continue
+		}
+
+		for j, replica := range p.Replicas {
+			// If one of the replicas is not being leadership evacuated, use that one and swap.
+			if _, contains := brokersMap[replica]; !contains {
+				newLeader := p.Replicas[j]
+				partitionMapOut.Partitions[i].Replicas[j] = p.Replicas[0]
+				partitionMapOut.Partitions[i].Replicas[0] = newLeader
+				break
+			}
+
+			// If we've tried every replica, but they are all being leader evac'd.
+			if replica == p.Replicas[len(p.Replicas)-1] {
+				fmt.Println("No replicas available to evacuate leadership to. All replicas present in EvacLeadership broker list.")
+				os.Exit(1)
+			}
+		}
+	}
+
+	return partitionMapOut
+}

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -30,11 +30,11 @@ func getPartitionMap(params rebuildParams, zk kafkazk.Handler) (*kafkazk.Partiti
 			os.Exit(1)
 		}
 		// Exclude topics explicitly listed.
-		et := removeTopics(pm, Config.topicsExclude)
+		et := removeTopics(pm, params.topicsExclude)
 		return pm, []string{}, et
 	// The map needs to be fetched via ZooKeeper metadata for all specified topics.
-	case len(Config.topics) > 0:
-		pm, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
+	case len(params.topics) > 0:
+		pm, err := kafkazk.PartitionMapFromZK(params.topics, zk)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -47,7 +47,7 @@ func getPartitionMap(params rebuildParams, zk kafkazk.Handler) (*kafkazk.Partiti
 		}
 
 		// Exclude topics explicitly listed.
-		et := removeTopics(pm, Config.topicsExclude)
+		et := removeTopics(pm, params.topicsExclude)
 
 		return pm, pd, et
 	}
@@ -100,7 +100,7 @@ func getBrokers(params rebuildParams, pm *kafkazk.PartitionMap, bm kafkazk.Broke
 	brokers := kafkazk.BrokerMapFromPartitionMap(pm, bm, params.forceRebuild)
 
 	// Update the currentBrokers list with the provided broker list.
-	bs, msgs := brokers.Update(Config.brokers, bm)
+	bs, msgs := brokers.Update(params.brokers, bm)
 	for m := range msgs {
 		fmt.Printf("%s%s\n", indent, m)
 	}

--- a/cmd/topicmappr/commands/root.go
+++ b/cmd/topicmappr/commands/root.go
@@ -25,5 +25,6 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().String("zk-addr", "localhost:2181", "ZooKeeper connect string")
 	rootCmd.PersistentFlags().String("zk-prefix", "", "ZooKeeper prefix (if Kafka is configured with a chroot path prefix)")
+	rootCmd.PersistentFlags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
 	rootCmd.PersistentFlags().Bool("ignore-warns", false, "Produce a map even if warnings are encountered")
 }

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -42,7 +42,10 @@ func scale(cmd *cobra.Command, _ []string) {
 	bootstrap(cmd)
 
 	// ZooKeeper init.
-	zk, err := initZooKeeper(cmd)
+	zkAddr := cmd.Parent().Flag("zk-addr").Value.String()
+	kafkaPrefix := cmd.Parent().Flag("zk-prefix").Value.String()
+	metricsPrefix := cmd.Flag("zk-metrics-prefix").Value.String()
+	zk, err := initZooKeeper(zkAddr, kafkaPrefix, metricsPrefix)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -55,9 +55,22 @@ func scale(cmd *cobra.Command, _ []string) {
 
 	// Get broker and partition metadata.
 	maxMetadataAge, _ := cmd.Flags().GetInt("metrics-age")
-	checkMetaAge(zk, maxMetadataAge)
-	brokerMeta := getBrokerMeta(zk, true)
-	partitionMeta := getPartitionMeta(zk)
+	if err := checkMetaAge(zk, maxMetadataAge); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	brokerMeta, errs := getBrokerMeta(zk, true)
+	if errs != nil && brokerMeta == nil {
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		os.Exit(1)
+	}
+	partitionMeta, err := getPartitionMeta(zk)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	// Get the current partition map.
 	partitionMapIn, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
@@ -67,7 +80,10 @@ func scale(cmd *cobra.Command, _ []string) {
 	}
 
 	// Exclude any topics that are pending deletion.
-	pending := stripPendingDeletes(partitionMapIn, zk)
+	pending, err := stripPendingDeletes(partitionMapIn, zk)
+	if err != nil {
+		fmt.Println("Error fetching topics pending deletion")
+	}
 
 	// Exclude any explicit exclusions.
 	excluded := removeTopics(partitionMapIn, Config.topicsExclude)
@@ -146,7 +162,7 @@ func scale(cmd *cobra.Command, _ []string) {
 	printMapChanges(partitionMapIn, partitionMapOut)
 
 	// Print broker assignment statistics.
-	errs := printBrokerAssignmentStats(cmd, partitionMapIn, partitionMapOut, brokersIn, brokersOut)
+	errs = printBrokerAssignmentStats(cmd, partitionMapIn, partitionMapOut, brokersIn, brokersOut)
 
 	// Handle errors that are possible
 	// to be overridden by the user (aka
@@ -177,7 +193,12 @@ func validateBrokersForScale(cmd *cobra.Command, brokers kafkazk.BrokerMap, bm k
 	}
 
 	// Check if any referenced brokers are marked as having missing/partial metrics data.
-	ensureBrokerMetrics(brokers, bm)
+	if errs := ensureBrokerMetrics(brokers, bm); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		os.Exit(1)
+	}
 
 	switch {
 	case c.Missing > 0, c.OldMissing > 0, c.Replace > 0:

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -30,7 +30,6 @@ func init() {
 	scaleCmd.Flags().Int("partition-size-threshold", 512, "Size in megabytes where partitions below this value will not be moved in a scale")
 	scaleCmd.Flags().Bool("locality-scoped", false, "Ensure that all partition movements are scoped by rack.id")
 	scaleCmd.Flags().Bool("verbose", false, "Verbose output")
-	scaleCmd.Flags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")
 	scaleCmd.Flags().Int("metrics-age", 60, "Kafka metrics age tolerance (in minutes)")
 	scaleCmd.Flags().Bool("optimize-leadership", false, "Scale all broker leader/follower ratios")
 

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -174,7 +174,9 @@ func scale(cmd *cobra.Command, _ []string) {
 	partitionMapIn, partitionMapOut = skipReassignmentNoOps(partitionMapIn, partitionMapOut)
 
 	// Write maps.
-	writeMaps(cmd, partitionMapOut, nil)
+	outPath := cmd.Flag("out-path").Value.String()
+	outFile := cmd.Flag("out-file").Value.String()
+	writeMaps(outPath, outFile, partitionMapOut, nil)
 }
 
 func validateBrokersForScale(cmd *cobra.Command, brokers kafkazk.BrokerMap, bm kafkazk.BrokerMetaMap) []int {

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -52,7 +52,7 @@ func scale(cmd *cobra.Command, _ []string) {
 
 	defer zk.Close()
 
-	partitionMap, _ := reassign(params, zk)
+	partitionMaps, _ := reassign(params, zk)
 
 	// TODO intentionally not handling the one error that can be returned here
 	// right now, but would be better to distinguish errors
@@ -60,5 +60,5 @@ func scale(cmd *cobra.Command, _ []string) {
 
 	outPath := cmd.Flag("out-path").Value.String()
 	outFile := cmd.Flag("out-file").Value.String()
-	writeMaps(outPath, outFile, partitionMap, nil)
+	writeMaps(outPath, outFile, partitionMaps)
 }

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -51,9 +51,10 @@ func scale(cmd *cobra.Command, _ []string) {
 	defer zk.Close()
 
 	// Get broker and partition metadata.
-	checkMetaAge(cmd, zk)
-	brokerMeta := getBrokerMeta(cmd, zk, true)
-	partitionMeta := getPartitionMeta(cmd, zk)
+	maxMetadataAge, _ := cmd.Flags().GetInt("metrics-age")
+	checkMetaAge(zk, maxMetadataAge)
+	brokerMeta := getBrokerMeta(zk, true)
+	partitionMeta := getPartitionMeta(zk)
 
 	// Get the current partition map.
 	partitionMapIn, err := kafkazk.PartitionMapFromZK(Config.topics, zk)
@@ -173,7 +174,7 @@ func validateBrokersForScale(cmd *cobra.Command, brokers kafkazk.BrokerMap, bm k
 	}
 
 	// Check if any referenced brokers are marked as having missing/partial metrics data.
-	ensureBrokerMetrics(cmd, brokers, bm)
+	ensureBrokerMetrics(brokers, bm)
 
 	switch {
 	case c.Missing > 0, c.OldMissing > 0, c.Replace > 0:

--- a/kafkazk/brokers.go
+++ b/kafkazk/brokers.go
@@ -160,6 +160,8 @@ type BrokerFilterFn func(*Broker) bool
 
 // AllBrokersFn returns all brokers.
 var AllBrokersFn BrokerFilterFn = func(b *Broker) bool { return true }
+var NotReplacedBrokersFn = func(b *Broker) bool { return !b.Replace }
+var ReplacedBrokersFn = func(b *Broker) bool { return b.Replace }
 
 // SortPseudoShuffle takes a BrokerList and performs a sort by count.
 // For each sequence of brokers with equal counts, the sub-slice is
@@ -343,7 +345,7 @@ func (b BrokerMap) Update(bl []int, bm BrokerMetaMap) (*BrokerStatus, <-chan str
 // SubStorageAll takes a PartitionMap, PartitionMetaMap, and a function. For all
 // brokers that return true as an input to function f, the size of all partitions
 // held is added back to the broker StorageFree value.
-func (b BrokerMap) SubStorage(pm *PartitionMap, pmm PartitionMetaMap, f func(*Broker) bool) error {
+func (b BrokerMap) SubStorage(pm *PartitionMap, pmm PartitionMetaMap, f BrokerFilterFn) error {
 	// Get the size of each partition.
 	for _, partn := range pm.Partitions {
 		size, err := pmm.Size(partn)

--- a/kafkazk/brokers_test.go
+++ b/kafkazk/brokers_test.go
@@ -270,8 +270,7 @@ func TestSubStorageReplacements(t *testing.T) {
 
 	bm[1003].Replace = true
 
-	replacedBrokers := func(b *Broker) bool { return b.Replace }
-	err := bm.SubStorage(pm, pmm, replacedBrokers)
+	err := bm.SubStorage(pm, pmm, ReplacedBrokersFn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kafkazk/constraints.go
+++ b/kafkazk/constraints.go
@@ -125,14 +125,7 @@ func (c *Constraints) Add(b *Broker) {
 func (c *Constraints) MergeConstraints(bl BrokerList) {
 	// Don't merge in attributes
 	// from nodes that will be removed.
-	var f BrokerFilterFn = func(b *Broker) bool {
-		if b.Replace {
-			return false
-		}
-		return true
-	}
-
-	for _, b := range bl.Filter(f) {
+	for _, b := range bl.Filter(NotReplacedBrokersFn) {
 		if b.Locality != "" {
 			c.locality[b.Locality] = true
 		}


### PR DESCRIPTION
This refactor is intended to pave the way for topicmappr as a service or as a library.
Refactoring of error handling and potentially of logging are still missing, but will likely be handled separately.