### PR TITLE
[registry] Handle SIGTERM gracefully

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/DataDog/kafka-kit/v3/kafkaadmin"
@@ -166,7 +167,7 @@ func main() {
 
 	// Graceful shutdown on SIGINT.
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
 		cancel()


### PR DESCRIPTION
This allows handling default k8s behavior [1].
    
[1] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination