### PR TITLE
[registry] Use descriptive error codes

### DIFF
--- a/registry/server/api_brokers.go
+++ b/registry/server/api_brokers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -10,17 +9,20 @@ import (
 
 	"github.com/DataDog/kafka-kit/v4/mapper"
 	pb "github.com/DataDog/kafka-kit/v4/registry/registry"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
 	// ErrFetchingBrokers error.
-	ErrFetchingBrokers = errors.New("error fetching brokers")
+	ErrFetchingBrokers = status.Error(codes.Internal, "error fetching brokers")
 	// ErrBrokerNotExist error.
-	ErrBrokerNotExist = errors.New("broker does not exist")
+	ErrBrokerNotExist = status.Error(codes.FailedPrecondition, "broker does not exist")
 	// ErrBrokerIDEmpty error.
-	ErrBrokerIDEmpty = errors.New("broker Id field must be specified")
+	ErrBrokerIDEmpty = status.Error(codes.InvalidArgument, "broker Id field must be specified")
 	// ErrBrokerIDsEmpty error.
-	ErrBrokerIDsEmpty = errors.New("broker Ids field must be specified")
+	ErrBrokerIDsEmpty = status.Error(codes.InvalidArgument, "broker Ids field must be specified")
 )
 
 // BrokerSet is a mapping of broker IDs to *pb.Broker.

--- a/registry/server/api_offset_translation.go
+++ b/registry/server/api_offset_translation.go
@@ -3,18 +3,20 @@ package server
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"log"
 	"time"
 
 	pb "github.com/DataDog/kafka-kit/v4/registry/registry"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
 	// ErrGroupIDEmpty error.
-	ErrGroupIDEmpty = errors.New("GroupId field must be specified")
+	ErrGroupIDEmpty = status.Error(codes.InvalidArgument, "GroupId field must be specified")
 )
 
 const (

--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -13,23 +12,26 @@ import (
 	"github.com/DataDog/kafka-kit/v4/kafkazk"
 	"github.com/DataDog/kafka-kit/v4/mapper"
 	pb "github.com/DataDog/kafka-kit/v4/registry/registry"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
 	// ErrFetchingTopics error.
-	ErrFetchingTopics = errors.New("error fetching topics")
+	ErrFetchingTopics = status.Error(codes.Internal, "error fetching topics")
 	// ErrTopicNotExist error.
-	ErrTopicNotExist = errors.New("topic does not exist")
+	ErrTopicNotExist = status.Error(codes.NotFound, "topic does not exist")
 	// ErrTopicNameEmpty error.
-	ErrTopicNameEmpty = errors.New("topic Name field must be specified")
+	ErrTopicNameEmpty = status.Error(codes.InvalidArgument, "topic Name field must be specified")
 	// ErrTopicFieldMissing error.
-	ErrTopicFieldMissing = errors.New("topic field missing in request body")
+	ErrTopicFieldMissing = status.Error(codes.InvalidArgument, "topic field missing in request body")
 	// ErrTopicAlreadyExists error.
-	ErrTopicAlreadyExists = errors.New("topic already exists")
+	ErrTopicAlreadyExists = status.Error(codes.AlreadyExists, "topic already exists")
 	// ErrInsufficientBrokers error.
-	ErrInsufficientBrokers = errors.New("insufficient number of brokers")
+	ErrInsufficientBrokers = status.Error(codes.FailedPrecondition, "insufficient number of brokers")
 	// ErrInvalidBrokerId error.
-	ErrInvalidBrokerId = errors.New("invalid broker id")
+	ErrInvalidBrokerId = status.Error(codes.FailedPrecondition, "invalid broker id")
 	// Misc.
 	allTopicsRegex = regexp.MustCompile(".*")
 )


### PR DESCRIPTION
This won't catch all situations in which a more descriptive error code
than `UNKNOWN` could be returned, but it improves on the most common
ones, and especially on the ones clients might want to know about, e.g.
that a topic to be created already exists.