### PR TITLE
[registry] Fix registry tag clean up

### DIFF
--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -44,7 +44,7 @@ func (tc *TagCleaner) RunTagCleanup(s *Server, ctx context.Context, c Config) {
 // MarkForDeletion marks stored tags that have been stranded without an associated
 // kafka resource.
 func (s *Server) MarkForDeletion(ctx context.Context, now func() time.Time) error {
-	markTimeMinutes := fmt.Sprint(now().Unix())
+	markTimeSeconds := fmt.Sprint(now().Unix())
 
 	// Get all brokers from ZK.
 	brokers, errs := s.ZK.GetAllBrokerMeta(false)
@@ -95,7 +95,7 @@ func (s *Server) MarkForDeletion(ctx context.Context, now func() time.Time) erro
 		// If the object doesn't exist and hasn't already been marked, do so.
 		if !objectExists && !marked {
 			log.Printf("marking %s:%s for cleanup\n", kafkaObject.Type, kafkaObject.ID)
-			tagSet[TagMarkTimeKey] = markTimeMinutes
+			tagSet[TagMarkTimeKey] = markTimeSeconds
 			if err := s.Tags.Store.SetTags(kafkaObject, tagSet); err != nil {
 				log.Printf("failed to update TagSet for %s %s: %s\n", kafkaObject.Type, kafkaObject.ID, err)
 			}

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -26,8 +26,7 @@ func (tc *TagCleaner) RunTagCleanup(s *Server, ctx context.Context, c Config) {
 	t := time.NewTicker(tickerPeriod)
 	defer t.Stop()
 
-	for tc.running {
-		<-t.C
+	for ; tc.running; <-t.C {
 
 		log.Println("running tag cleanup")
 		if err := s.MarkForDeletion(ctx, time.Now); err != nil {

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -101,13 +101,13 @@ func (s *Server) MarkForDeletion(ctx context.Context, now func() time.Time) erro
 			continue
 		}
 
-		// Otherwise, the object exists and we should remove the marker if it were
-		// previously set.
-		if marked {
+		// If the object exists but has been marked, remove the mark.
+		if objectExists && marked {
 			log.Printf("unmarking existing %s:%s to avoid cleanup\n", kafkaObject.Type, kafkaObject.ID)
 			if err := s.Tags.Store.DeleteTags(kafkaObject, []string{TagMarkTimeKey}); err != nil {
 				log.Printf("failed to remove %s tag for %s %s: %s\n", TagMarkTimeKey, kafkaObject.Type, kafkaObject.ID, err)
 			}
+			continue
 		}
 	}
 

--- a/registry/server/tag_cleanup.go
+++ b/registry/server/tag_cleanup.go
@@ -107,7 +107,7 @@ func (s *Server) MarkForDeletion(ctx context.Context, now func() time.Time) erro
 		if marked {
 			log.Printf("unmarking existing %s:%s to avoid cleanup\n", kafkaObject.Type, kafkaObject.ID)
 			if err := s.Tags.Store.DeleteTags(kafkaObject, []string{TagMarkTimeKey}); err != nil {
-				log.Printf("failed to remove TagMarkTimeKey tag for %s %s: %s\n", kafkaObject.Type, kafkaObject.ID, err)
+				log.Printf("failed to remove %s tag for %s %s: %s\n", TagMarkTimeKey, kafkaObject.Type, kafkaObject.ID, err)
 			}
 		}
 	}


### PR DESCRIPTION
The tag clean up currently unmarks resources marked for deletion after marking them.