### PR TITLE
Jamie/topicmappr zkless

### DIFF
--- a/cmd/topicmappr/commands/metadata.go
+++ b/cmd/topicmappr/commands/metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"time"
 
 	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
@@ -45,6 +46,20 @@ func getBrokerMeta(ka kafkaadmin.KafkaAdmin, zk kafkazk.Handler, m bool) (mapper
 	}
 
 	return brokers, nil
+}
+
+func getPartitionMaps(ka kafkaadmin.KafkaAdmin, topics []string) (*mapper.PartitionMap, error) {
+	// Get the topic states.
+	tState, err := ka.DescribeTopics(context.Background(), topics)
+	if err != nil {
+		return nil, err
+	}
+
+	// Translate it to a mapper object.
+	pm, _ := mapper.PartitionMapFromTopicStates(tState)
+	sort.Sort(pm.Partitions)
+
+	return pm, nil
 }
 
 // ensureBrokerMetrics takes a map of reference brokers and a map of discovered

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
 	"github.com/DataDog/kafka-kit/v4/kafkazk"
 	"github.com/DataDog/kafka-kit/v4/mapper"
 
@@ -80,7 +81,7 @@ func reassignParamsFromCmd(cmd *cobra.Command) (params reassignParams) {
 	return params
 }
 
-func reassign(params reassignParams, zk kafkazk.Handler) ([]*mapper.PartitionMap, []error) {
+func reassign(params reassignParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handler) ([]*mapper.PartitionMap, []error) {
 	// Get broker and partition metadata.
 	if err := checkMetaAge(zk, params.maxMetadataAge); err != nil {
 		fmt.Println(err)

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -107,12 +107,6 @@ func reassign(params reassignParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handle
 		os.Exit(1)
 	}
 
-	// Exclude any topics that are pending deletion.
-	pending, err := stripPendingDeletes(partitionMapIn, zk)
-	if err != nil {
-		fmt.Println("Error fetching topics pending deletion")
-	}
-
 	// Exclude any explicit exclusions.
 	excluded := removeTopics(partitionMapIn, params.topicsExclude)
 
@@ -120,7 +114,7 @@ func reassign(params reassignParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handle
 	printTopics(partitionMapIn)
 
 	// Print if any topics were excluded due to pending deletion.
-	printExcludedTopics(pending, excluded)
+	printExcludedTopics(nil, excluded)
 
 	// Get a broker map.
 	brokersIn := mapper.BrokerMapFromPartitionMap(partitionMapIn, brokerMeta, false)

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -45,7 +45,7 @@ type reassignParams struct {
 	storageThreshold       float64
 	storageThresholdGB     float64
 	tolerance              float64
-	topics                 []*regexp.Regexp
+	topics                 []string
 	topicsExclude          []*regexp.Regexp
 	requireNewBrokers      bool
 	verbose                bool
@@ -73,7 +73,7 @@ func reassignParamsFromCmd(cmd *cobra.Command) (params reassignParams) {
 	tolerance, _ := cmd.Flags().GetFloat64("tolerance")
 	params.tolerance = tolerance
 	topics, _ := cmd.Flags().GetString("topics")
-	params.topics = topicRegex(topics)
+	params.topics = strings.Split(topics, ",")
 	topicsExclude, _ := cmd.Flags().GetString("topics-exclude")
 	params.topicsExclude = topicRegex(topicsExclude)
 	verbose, _ := cmd.Flags().GetBool("verbose")
@@ -101,7 +101,7 @@ func reassign(params reassignParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handle
 	}
 
 	// Get the current partition map.
-	partitionMapIn, err := kafkazk.PartitionMapFromZK(params.topics, zk)
+	partitionMapIn, err := getPartitionMaps(ka, params.topics)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/topicmappr/commands/reassignments.go
+++ b/cmd/topicmappr/commands/reassignments.go
@@ -87,7 +87,7 @@ func reassign(params reassignParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handle
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	brokerMeta, errs := getBrokerMeta(zk, true)
+	brokerMeta, errs := getBrokerMeta(ka, zk, true)
 	if errs != nil && brokerMeta == nil {
 		for _, e := range errs {
 			fmt.Println(e)

--- a/cmd/topicmappr/commands/rebalance.go
+++ b/cmd/topicmappr/commands/rebalance.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
+
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +56,15 @@ func rebalance(cmd *cobra.Command, _ []string) {
 
 	defer zk.Close()
 
-	partitionMaps, errs := reassign(params, zk)
+	// Init kafkaadmin client.
+	bs := cmd.Parent().Flag("kafka-addr").Value.String()
+	ka, err := kafkaadmin.NewClient(kafkaadmin.Config{BootstrapServers: bs})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	partitionMaps, errs := reassign(params, ka, zk)
 
 	// Handle errors that are possible to be overridden by the user (aka 'WARN'
 	// in topicmappr console output).

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
 	"github.com/DataDog/kafka-kit/v4/kafkazk"
@@ -66,7 +67,7 @@ type rebuildParams struct {
 	replication         int
 	skipNoOps           bool
 	subAffinity         bool
-	topics              []*regexp.Regexp
+	topics              []string
 	topicsExclude       []*regexp.Regexp
 	useMetadata         bool
 	leaderEvacTopics    []*regexp.Regexp
@@ -102,7 +103,7 @@ func rebuildParamsFromCmd(cmd *cobra.Command) (params rebuildParams) {
 	subAffinity, _ := cmd.Flags().GetBool("sub-affinity")
 	params.subAffinity = subAffinity
 	topics, _ := cmd.Flags().GetString("topics")
-	params.topics = topicRegex(topics)
+	params.topics = strings.Split(topics, ",")
 	topicsExclude, _ := cmd.Flags().GetString("topics-exclude")
 	params.topicsExclude = topicRegex(topicsExclude)
 	useMetadata, _ := cmd.Flags().GetBool("use-meta")

--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -70,7 +70,7 @@ type rebuildParams struct {
 	topics              []string
 	topicsExclude       []*regexp.Regexp
 	useMetadata         bool
-	leaderEvacTopics    []*regexp.Regexp
+	leaderEvacTopics    []string
 	leaderEvacBrokers   []int
 	chunkStepSize       int
 }
@@ -111,9 +111,7 @@ func rebuildParamsFromCmd(cmd *cobra.Command) (params rebuildParams) {
 	chunkStepSize, _ := cmd.Flags().GetInt("chunk-step-size")
 	params.chunkStepSize = chunkStepSize
 	let, _ := cmd.Flags().GetString("leader-evac-topics")
-	if let != "" {
-		params.leaderEvacTopics = topicRegex(let)
-	}
+	params.leaderEvacTopics = strings.Split(let, ",")
 	leb, _ := cmd.Flags().GetString("leader-evac-brokers")
 	if leb != "" {
 		params.leaderEvacBrokers = brokerStringToSlice(leb)

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -48,7 +48,7 @@ func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handl
 	var brokerMeta mapper.BrokerMetaMap
 	var errs []error
 	if params.useMetadata {
-		if brokerMeta, errs = getBrokerMeta(zk, withMetrics); errs != nil && brokerMeta == nil {
+		if brokerMeta, errs = getBrokerMeta(ka, zk, withMetrics); errs != nil && brokerMeta == nil {
 			for _, e := range errs {
 				fmt.Println(e)
 			}

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -67,7 +67,7 @@ func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handl
 
 	// Build a partition map either from literal map text input or by fetching the
 	// map data from ZooKeeper. Store a copy of the original.
-	partitionMapIn, pending, excluded := getPartitionMap(params, zk)
+	partitionMapIn, _, excluded := getPartitionMap(params, zk)
 	originalMap := partitionMapIn.Copy()
 
 	// Get a list of affected topics.
@@ -75,7 +75,7 @@ func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handl
 
 	// Print if any topics were excluded due to pending deletion or explicit
 	// exclusion.
-	printExcludedTopics(pending, excluded)
+	printExcludedTopics(nil, excluded)
 
 	brokers, bs := getBrokers(params, partitionMapIn, brokerMeta)
 	brokersOrig := brokers.Copy()
@@ -198,16 +198,10 @@ func getPartitionMap(params rebuildParams, zk kafkazk.Handler) (*mapper.Partitio
 			os.Exit(1)
 		}
 
-		// Exclude any topics that are pending deletion.
-		pd, err := stripPendingDeletes(pm, zk)
-		if err != nil {
-			fmt.Println("Error fetching topics pending deletion")
-		}
-
 		// Exclude topics explicitly listed.
 		et := removeTopics(pm, params.topicsExclude)
 
-		return pm, pd, et
+		return pm, nil, et
 	}
 
 	return nil, nil, nil

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
 	"github.com/DataDog/kafka-kit/v4/kafkazk"
 	"github.com/DataDog/kafka-kit/v4/mapper"
 )
 
-func runRebuild(params rebuildParams, zk kafkazk.Handler) ([]*mapper.PartitionMap, []error) {
+func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handler) ([]*mapper.PartitionMap, []error) {
 	// General flow:
 	// 1) A PartitionMap is formed (either unmarshaled from the literal
 	//   map input via --rebuild-map or generated from ZooKeeper Metadata

--- a/cmd/topicmappr/commands/rebuild_steps.go
+++ b/cmd/topicmappr/commands/rebuild_steps.go
@@ -67,7 +67,7 @@ func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handl
 
 	// Build a partition map either from literal map text input or by fetching the
 	// map data from ZooKeeper. Store a copy of the original.
-	partitionMapIn, _, excluded := getPartitionMap(params, zk)
+	partitionMapIn, _, excluded := getPartitionMap(params, ka, zk)
 	originalMap := partitionMapIn.Copy()
 
 	// Get a list of affected topics.
@@ -176,7 +176,7 @@ func runRebuild(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handl
 // via the --topics flag. Two []string are returned; topics excluded due to
 // pending deletion and topics explicitly excluded (via the --topics-exclude
 // flag), respectively.
-func getPartitionMap(params rebuildParams, zk kafkazk.Handler) (*mapper.PartitionMap, []string, []string) {
+func getPartitionMap(params rebuildParams, ka kafkaadmin.KafkaAdmin, zk kafkazk.Handler) (*mapper.PartitionMap, []string, []string) {
 
 	switch {
 	// The map was provided as text.
@@ -192,7 +192,7 @@ func getPartitionMap(params rebuildParams, zk kafkazk.Handler) (*mapper.Partitio
 		return pm, []string{}, et
 	// The map needs to be fetched via ZooKeeper metadata for all specified topics.
 	case len(params.topics) > 0:
-		pm, err := kafkazk.PartitionMapFromZK(params.topics, zk)
+		pm, err := getPartitionMaps(ka, params.topics)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/topicmappr/commands/root.go
+++ b/cmd/topicmappr/commands/root.go
@@ -23,6 +23,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().String("kafka-addr", "localhost:9092", "Kafka bootstrap address")
 	rootCmd.PersistentFlags().String("zk-addr", "localhost:2181", "ZooKeeper connect string")
 	rootCmd.PersistentFlags().String("zk-prefix", "", "ZooKeeper prefix (if Kafka is configured with a chroot path prefix)")
 	rootCmd.PersistentFlags().String("zk-metrics-prefix", "topicmappr", "ZooKeeper namespace prefix for Kafka metrics")

--- a/cmd/topicmappr/commands/scale.go
+++ b/cmd/topicmappr/commands/scale.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/kafka-kit/v4/kafkaadmin"
+
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +54,15 @@ func scale(cmd *cobra.Command, _ []string) {
 
 	defer zk.Close()
 
-	partitionMaps, _ := reassign(params, zk)
+	// Init kafkaadmin client.
+	bs := cmd.Parent().Flag("kafka-addr").Value.String()
+	ka, err := kafkaadmin.NewClient(kafkaadmin.Config{BootstrapServers: bs})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	partitionMaps, _ := reassign(params, ka, zk)
 
 	// TODO intentionally not handling the one error that can be returned here
 	// right now, but would be better to distinguish errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "2181:2181"
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost:2181"]
+      test: nc -z localhost 2181 || exit -1
       interval: 5s
       timeout: 5s
       retries: 5
@@ -41,11 +41,11 @@ services:
       - "9092"
       - "9093"
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost:9092"]
+      test: nc -z localhost 9092 || exit -1
       interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 5s
+      start_period: 15s
     depends_on:
       - ssl_setup
       - zookeeper
@@ -93,7 +93,7 @@ services:
       - "8080"
       - "8090"
     healthcheck:
-      test: ["CMD", "curl", "-f", "localhost:8080/v1/brokers/list"]
+      test: curl -f localhost:8080/v1/brokers/list
       interval: 5s
       timeout: 5s
       retries: 5

--- a/kafkazk/mapper.go
+++ b/kafkazk/mapper.go
@@ -1,0 +1,30 @@
+package kafkazk
+
+import (
+	"fmt"
+
+	"github.com/DataDog/kafka-kit/v4/mapper"
+)
+
+// LoadMetrics takes a Handler and fetches stored broker metrics, populating the
+// BrokerMetaMap.
+func LoadMetrics(zk Handler, bm mapper.BrokerMetaMap) []error {
+	metrics, err := zk.GetBrokerMetrics()
+	if err != nil {
+		return []error{err}
+	}
+
+	// Populate each broker with metric data.
+	var errs []error
+	for id := range bm {
+		m, exists := metrics[id]
+		if !exists {
+			errs = append(errs, fmt.Errorf("Metrics not found for broker %d", id))
+			bm[id].MetricsIncomplete = true
+		} else {
+			bm[id].StorageFree = m.StorageFree
+		}
+	}
+
+	return errs
+}

--- a/kafkazk/zookeeper.go
+++ b/kafkazk/zookeeper.go
@@ -23,6 +23,7 @@ import (
 // configuration methods.
 type Handler interface {
 	SimpleZooKeeperClient
+	GetBrokerMetrics() (mapper.BrokerMetricsMap, error)
 	GetTopicState(string) (*mapper.TopicState, error)
 	GetTopicStateISR(string) (TopicStateISR, error)
 	UpdateKafkaConfig(KafkaConfig) ([]bool, error)
@@ -409,7 +410,7 @@ func (z *ZKHandler) GetAllBrokerMeta(withMetrics bool) (mapper.BrokerMetaMap, []
 
 	// Fetch and populate in metrics.
 	if withMetrics {
-		bmetrics, err := z.getBrokerMetrics()
+		bmetrics, err := z.GetBrokerMetrics()
 		if err != nil {
 			return nil, []error{err}
 		}
@@ -432,7 +433,7 @@ func (z *ZKHandler) GetAllBrokerMeta(withMetrics bool) (mapper.BrokerMetaMap, []
 
 // GetBrokerMetrics fetches broker metrics stored in ZooKeeper and returns a
 // BrokerMetricsMap and an error if encountered.
-func (z *ZKHandler) getBrokerMetrics() (mapper.BrokerMetricsMap, error) {
+func (z *ZKHandler) GetBrokerMetrics() (mapper.BrokerMetricsMap, error) {
 	path := z.getMetricsPath("/brokermetrics")
 
 	// Fetch the metrics object.


### PR DESCRIPTION
Adds the `--kafka-addr` flag to `topicmappr`. Reimplements all topic and broker state fetching to use `kafkaadmin` rather than pulling the data directly from ZooKeeper. Retains use of storing/loading metrics data (ie that from `metricsfetcher`) via ZooKeeper as a generic storage engine.