### PR TITLE
[registry] CreateTopic tagging retries

### DIFF
--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -32,7 +32,7 @@ var (
 	// ErrInvalidBrokerId error.
 	ErrInvalidBrokerId = status.Error(codes.FailedPrecondition, "invalid broker id")
 	// ErrTaggingTopicTimedOut
-	ErrTaggingTopicTimedOut = status.Error(codes.Internal, "tagging topic timed out")
+	ErrTaggingTopicTimedOut = status.Error(codes.DeadlineExceeded, "tagging topic timed out")
 )
 
 // TopicSet is a mapping of topic name to *pb.Topic.

--- a/registry/server/api_topics.go
+++ b/registry/server/api_topics.go
@@ -317,7 +317,7 @@ func (s *Server) tagTopicWithRetries(ctx context.Context, req *pb.TopicRequest) 
 	// - returns at the context timeout
 	delay := 250 * time.Millisecond
 	maxDelay := 5 * time.Second
-	maxRetries := 10
+	maxRetries := 100
 
 	var err error
 


### PR DESCRIPTION
The current `CreateTopic` rpc can optionally take tags. When provided, the tagging operation runs immediately after the request to create the topic in Kafka, which can show lag at time, especially with large partition counts.

This change adds a backoff retry mechanism to improve the creation of tagged topics.

Before:
```
 % curl -XPOST $(docker port kafka-kit_registry_1 8080)/v1/topics/create -d '{"topic": {"name": "test8", "partitions": 500, "replication": 2, "tags": {"key":"value"}}}'
{"code":5, "message":"topic does not exist", "details":[]}
```

After:
```
% curl -XPOST $(docker port kafka-kit_registry_1 8080)/v1/topics/create -d '{"topic": {"name": "test9", "partitions": 500, "replication": 2, "tags": {"key":"value"}}}'
{}
```