### PR TITLE
[autothrottle] Apply API changes immediately

### DIFF
--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -120,7 +120,8 @@ func main() {
 		ZKPrefix: Config.ConfigZKPrefix,
 	}
 
-	api.Init(apiConfig, zk)
+	trigger := make(chan struct{}, 1)
+	api.Init(apiConfig, zk, trigger)
 	log.Printf("Admin API: %s\n", Config.APIListen)
 
 	// Init a Kafka metrics fetcher.
@@ -207,7 +208,6 @@ func main() {
 
 	// TODO(jamie): refactor this loop.
 	for {
-		interval++
 
 		// Get topics undergoing reassignment.
 		if !Config.KafkaNativeMode {
@@ -444,7 +444,11 @@ func main() {
 				}
 			}
 		}
-		<-ticker.C
+		select {
+		case <-ticker.C:
+			interval++
+		case <-trigger:
+		}
 	}
 
 }

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -206,7 +206,7 @@ func main() {
 	var ticker = time.NewTicker(time.Duration(Config.Interval) * time.Second)
 
 	// TODO(jamie): refactor this loop.
-	for ; ; <-ticker.C {
+	for {
 		interval++
 
 		// Get topics undergoing reassignment.
@@ -444,7 +444,7 @@ func main() {
 				}
 			}
 		}
-
+		<-ticker.C
 	}
 
 }


### PR DESCRIPTION
This change will short-circuit the autothrottle control loop immediately when a throttle is applied via the API, allowing easier outside control of throttles.