### PR TITLE
[topicmappr] Allow empty leaderEvacTopic/Broker lists

### DIFF
--- a/cmd/topicmappr/commands/rebuild.go
+++ b/cmd/topicmappr/commands/rebuild.go
@@ -111,7 +111,9 @@ func rebuildParamsFromCmd(cmd *cobra.Command) (params rebuildParams) {
 	chunkStepSize, _ := cmd.Flags().GetInt("chunk-step-size")
 	params.chunkStepSize = chunkStepSize
 	let, _ := cmd.Flags().GetString("leader-evac-topics")
-	params.leaderEvacTopics = strings.Split(let, ",")
+	if let != "" {
+		params.leaderEvacTopics = strings.Split(let, ",")
+	}
 	leb, _ := cmd.Flags().GetString("leader-evac-brokers")
 	if leb != "" {
 		params.leaderEvacBrokers = brokerStringToSlice(leb)


### PR DESCRIPTION
When trying to perform a rebuild, without specifying topics/brokers for leadership evacuation, the `topicmappr rebuild` command will always fail.

Looking at the `validate` code we see that there is a check that either both or none of `leaderEvacTopics` and `leaderEvacBrokers` are empty:
```
case (len(c.leaderEvacBrokers) != 0 || len(c.leaderEvacTopics) != 0) && (len(c.leaderEvacBrokers) == 0 || len(c.leaderEvacTopics) == 0):			case (len(c.leaderEvacBrokers) != 0 || len(c.leaderEvacTopics) != 0) && (len(c.leaderEvacBrokers) == 0 || len(c.leaderEvacTopics) == 0):
		return fmt.Errorf("\n[ERROR] --leader-evac-topics and --leader-evac-brokers must both be specified for leadership evacuation.")
```

However, because `strings.Split("", ",")` returns `[]string{""}`, there is no current way for the leaderEvacTopics to be an empty list. This PR just adds an additional check, exactly as is done with `leaderEvacBrokers` so that if we don't specify a value for this flag, we get an empty list and can pass the validation.