### PR TITLE
Fix throttling replica list after a broker replacement

### DIFF
--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -318,8 +318,10 @@ func main() {
 		}
 
 		// Get brokers with active overrides, ie where the override rate is non-0,
-		// that are also not part of a reassignment.
-		fn := replication.NotReassignmentParticipant
+		// this includes both brokers with manual overrides and part of broker
+		// replacement process (previously we filtered for brokers that were
+		// also not part of a reassignment).
+		fn := replication.AlsoReassignmentParticipant
 		activeOverrideBrokers := throttleManager.GetBrokerOverrides().Filter(fn)
 
 		// Apply any additional broker-specific throttles that were not applied as
@@ -344,11 +346,14 @@ func main() {
 
 			// Determine whether we need to propagate topic throttle replica
 			// list configs. If the brokers with overrides remains the same,
-			// we don't need to need to update those configs.
+			// we don't need to update those configs.
 			var brokersThrottledNow = newSet()
 			for broker := range activeOverrideBrokers {
 				brokersThrottledNow.add(strconv.Itoa(broker))
 			}
+
+			log.Printf("BrokersThrottledNow: %v", brokersThrottledNow)
+			log.Printf("BrokersThrottledPreviously: %v", brokersThrottledPreviously)
 
 			if brokersThrottledNow.equal(brokersThrottledPreviously) {
 				throttleManager.DisableOverrideTopicUpdates()

--- a/cmd/autothrottle/main.go
+++ b/cmd/autothrottle/main.go
@@ -317,11 +317,9 @@ func main() {
 			}
 		}
 
-		// Get brokers with active overrides, ie where the override rate is non-0,
-		// this includes both brokers with manual overrides and part of broker
-		// replacement process (previously we filtered for brokers that were
-		// also not part of a reassignment).
-		fn := replication.AlsoReassignmentParticipant
+		// Get brokers with active overrides, ie where the override rate is non-0.
+		// Note: this includes brokers that may or may not be part of reassignment.
+		fn := replication.HasActiveOverride
 		activeOverrideBrokers := throttleManager.GetBrokerOverrides().Filter(fn)
 
 		// Apply any additional broker-specific throttles that were not applied as
@@ -351,9 +349,6 @@ func main() {
 			for broker := range activeOverrideBrokers {
 				brokersThrottledNow.add(strconv.Itoa(broker))
 			}
-
-			log.Printf("BrokersThrottledNow: %v", brokersThrottledNow)
-			log.Printf("BrokersThrottledPreviously: %v", brokersThrottledPreviously)
 
 			if brokersThrottledNow.equal(brokersThrottledPreviously) {
 				throttleManager.DisableOverrideTopicUpdates()

--- a/internal/autothrottle/replication/throttles.go
+++ b/internal/autothrottle/replication/throttles.go
@@ -179,6 +179,11 @@ func NotReassignmentParticipant(bto throttlestore.BrokerThrottleOverride) bool {
 	return !bto.ReassignmentParticipant && bto.Config.Rate != 0
 }
 
+// AlsoReassignmentParticipant filter func.
+func AlsoReassignmentParticipant(bto throttlestore.BrokerThrottleOverride) bool {
+	return bto.Config.Rate != 0
+}
+
 // ThrottledBrokers is a list of brokers with a throttle applied
 // for an ongoing reassignment.
 type ThrottledBrokers struct {

--- a/internal/autothrottle/replication/throttles.go
+++ b/internal/autothrottle/replication/throttles.go
@@ -174,16 +174,6 @@ func HasActiveOverride(bto throttlestore.BrokerThrottleOverride) bool {
 	return bto.Config.Rate != 0
 }
 
-// NotReassignmentParticipant filter func.
-func NotReassignmentParticipant(bto throttlestore.BrokerThrottleOverride) bool {
-	return !bto.ReassignmentParticipant && bto.Config.Rate != 0
-}
-
-// AlsoReassignmentParticipant filter func.
-func AlsoReassignmentParticipant(bto throttlestore.BrokerThrottleOverride) bool {
-	return bto.Config.Rate != 0
-}
-
 // ThrottledBrokers is a list of brokers with a throttle applied
 // for an ongoing reassignment.
 type ThrottledBrokers struct {

--- a/internal/autothrottle/replication/throttles_update.go
+++ b/internal/autothrottle/replication/throttles_update.go
@@ -190,17 +190,13 @@ func (tm *ThrottleManager) UpdateOverrideThrottles() error {
 	var toRemove = make(map[int]struct{})
 
 	for _, override := range tm.brokerOverrides {
-		// ReassignmentParticipant have already had their override rate used as part
-		// of an ongoing reassignment.
-		if !override.ReassignmentParticipant {
-			rate := float64(override.Config.Rate)
-			// Rate == 0 means the rate was removed via the API.
-			if rate == 0 {
-				toRemove[override.ID] = struct{}{}
-			} else {
-				toAssign[override.ID] = struct{}{}
-				capacities.storeLeaderAndFollerCapacity(override.ID, rate)
-			}
+		rate := float64(override.Config.Rate)
+		// Rate == 0 means the rate was removed via the API.
+		if rate == 0 {
+			toRemove[override.ID] = struct{}{}
+		} else {
+			toAssign[override.ID] = struct{}{}
+			capacities.storeLeaderAndFollerCapacity(override.ID, rate)
 		}
 	}
 

--- a/internal/autothrottle/replication/topics.go
+++ b/internal/autothrottle/replication/topics.go
@@ -88,7 +88,7 @@ func (tm *ThrottleManager) GetTopicsWithThrottledBrokers() (TopicThrottledReplic
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
-	throttledBrokers := tm.brokerOverrides.Filter(AlsoReassignmentParticipant)
+	throttledBrokers := tm.brokerOverrides.Filter(HasActiveOverride)
 
 	// Construct a TopicThrottledReplicas that includes any topics with replicas
 	// assigned to brokers with overrides. The throttled list only includes brokers

--- a/internal/autothrottle/replication/topics.go
+++ b/internal/autothrottle/replication/topics.go
@@ -88,7 +88,7 @@ func (tm *ThrottleManager) GetTopicsWithThrottledBrokers() (TopicThrottledReplic
 	}
 
 	// Lookup brokers with overrides set that are not a reassignment participant.
-	throttledBrokers := tm.brokerOverrides.Filter(NotReassignmentParticipant)
+	throttledBrokers := tm.brokerOverrides.Filter(AlsoReassignmentParticipant)
 
 	// Construct a TopicThrottledReplicas that includes any topics with replicas
 	// assigned to brokers with overrides. The throttled list only includes brokers

--- a/internal/autothrottle/replication/topics_legacy.go
+++ b/internal/autothrottle/replication/topics_legacy.go
@@ -19,8 +19,9 @@ func (tm *ThrottleManager) legacyGetTopicsWithThrottledBrokers() (TopicThrottled
 		return nil, err
 	}
 
-	// Lookup brokers with overrides set that are not a reassignment participant.
-	throttledBrokers := tm.brokerOverrides.Filter(NotReassignmentParticipant)
+	//Lookup brokers with overrides set (previously we only filtered for brokers
+	// that are not a reassignment participant).
+	throttledBrokers := tm.brokerOverrides.Filter(AlsoReassignmentParticipant)
 
 	// Construct a TopicThrottledReplicas that includes any topics with replicas
 	// assigned to brokers with overrides. The throttled list only includes brokers

--- a/internal/autothrottle/replication/topics_legacy.go
+++ b/internal/autothrottle/replication/topics_legacy.go
@@ -19,9 +19,8 @@ func (tm *ThrottleManager) legacyGetTopicsWithThrottledBrokers() (TopicThrottled
 		return nil, err
 	}
 
-	//Lookup brokers with overrides set (previously we only filtered for brokers
-	// that are not a reassignment participant).
-	throttledBrokers := tm.brokerOverrides.Filter(AlsoReassignmentParticipant)
+	//Lookup brokers with overrides set.
+	throttledBrokers := tm.brokerOverrides.Filter(HasActiveOverride)
 
 	// Construct a TopicThrottledReplicas that includes any topics with replicas
 	// assigned to brokers with overrides. The throttled list only includes brokers

--- a/internal/autothrottle/replication/topics_test.go
+++ b/internal/autothrottle/replication/topics_test.go
@@ -72,11 +72,12 @@ func TestGetTopicsWithThrottledBrokers(t *testing.T) {
 	topicThrottledBrokers, _ := rtf.GetTopicsWithThrottledBrokers()
 
 	expected := TopicThrottledReplicas{
-		"test1": Throttled{"followers": BrokerIDs{"0:1001"}},
+		"test1": Throttled{"followers": BrokerIDs{"0:1001", "0:1002", "1:1002"}},
+		"test2": Throttled{"followers": BrokerIDs{"0:1002", "1:1002"}},
 	}
 
 	if len(topicThrottledBrokers) != len(expected) {
-		t.Fatalf("Expected len %d, got %d, expected- %v and actual - %v", len(expected), len(topicThrottledBrokers), expected, topicThrottledBrokers)
+		t.Fatalf("Expected len %d, got %d", len(expected), len(topicThrottledBrokers))
 	}
 
 	for topic := range expected {

--- a/internal/autothrottle/replication/topics_test.go
+++ b/internal/autothrottle/replication/topics_test.go
@@ -76,7 +76,7 @@ func TestGetTopicsWithThrottledBrokers(t *testing.T) {
 	}
 
 	if len(topicThrottledBrokers) != len(expected) {
-		t.Fatalf("Expected len %d, got %d", len(expected), len(topicThrottledBrokers))
+		t.Fatalf("Expected len %d, got %d, expected- %v and actual - %v", len(expected), len(topicThrottledBrokers), expected, topicThrottledBrokers)
 	}
 
 	for topic := range expected {


### PR DESCRIPTION
During a broker replacement it was noticed that a broker that was previously involved in reassignment when got replaced with a new node (it is common for brokers to fail and get a replacement node) did not throttle all the topic replicas the broker was hosting and that led to increase network usage and eventually more load on the broker affecting clients connected to it causing latency issues. The proposed fix is to refresh the replica throttled list when there is a broker override irrespective of the broker involvement in other reassignments. More details can be found in the notebook - https://ddstaging.datadoghq.com/notebook/6601106/investigating-missing-throttles-on-topics-after-broker-replacement#overview