### PR TITLE
[Metricsfetcher] Change broker query to use last instead of rollup

### DIFF
--- a/cmd/metricsfetcher/main.go
+++ b/cmd/metricsfetcher/main.go
@@ -61,7 +61,7 @@ func init() {
 	}
 
 	// Complete query string.
-	config.BrokerQuery = fmt.Sprintf("%s by {%s}.rollup(avg, %d)", *bq, config.BrokerIDTag, config.Span)
+	config.BrokerQuery = fmt.Sprintf("%s by {%s}.fill(last)", *bq, config.BrokerIDTag)
 	config.PartnQuery = fmt.Sprintf("%s.rollup(avg, %d)", *pq, config.Span)
 }
 


### PR DESCRIPTION
Recently there were a few occurrences on kafka metrics cluster when a rebalance operation was triggered (where a cluster was due a rebalance) and one of the broker which was recently replacement shot up to 90% in disk usage. The reason was due to a misinterpretation of metrics when fetched using metricsfetcher which uses a rollup function over 1 hour to get the avg free disk free per broker for a cluster which later gets used by topicmappr to compute the replica movement. For a more ideal and a reliable solution replacing `rollup` with `last`. More details here in the notebook - https://ddstaging.datadoghq.com/notebook/6622198/metricsfetcher-query-change-testing